### PR TITLE
Add Lighthouse CI GitHub Action

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,19 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli@0.12.x
+      - name: Run Lighthouse CI
+        run: lhci autorun

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,10 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["https://viktor-shcherb.github.io/"]
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- set up Lighthouse CI workflow for pull requests
- configure lighthouse with target URL

## Testing
- `npm install -g @lhci/cli@0.12.x` *(fails: 403 Forbidden, network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d142f0e4083318b937d28513f28d5