### PR TITLE
Fix CLS and serve latest post at /blog

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,19 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ---- build dynamic URL list from the sitemap -------------------------
-      - id: urls
-        run: |
-          curl -s https://viktor-shcherb.github.io/sitemap.xml \
-            | grep -Eo '<loc>[^<]+' | sed 's/<loc>//' > urls.txt
-          echo "URLS<<EOF" >> $GITHUB_ENV
-          cat urls.txt >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      # ---- Lighthouse ------------------------------------------------------
       - name: Audit live site with Lighthouse
         uses: treosh/lighthouse-ci-action@v12
         with:
-          urls: ${{ env.URLS }}
+          configPath: ./lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,10 @@
+---
+layout: default
+---
+<h1>{{ page.title }}</h1>
+<p class="post-meta">
+  <time datetime="{{ page.date | date_to_xmlschema }}">
+    {{ page.date | date: "%b %-d, %Y" }}
+  </time>
+</p>
+{{ content }}

--- a/_posts/2025-06-26-Path-to-working-permit-for-Swiss-graduates.md
+++ b/_posts/2025-06-26-Path-to-working-permit-for-Swiss-graduates.md
@@ -22,7 +22,11 @@ tags:
   - Higher education
 ---
 
-![Photo by Piotr Guzik, Unsplash.com]({{ page.image }})  
+<img src="{{ page.image }}"
+     alt="Photo by Piotr Guzik, Unsplash.com"
+     width="1200" height="630"
+     loading="lazy"
+     decoding="async">
 *Photo by Piotr Guzik / Unsplash*
 {: .img-caption }
 

--- a/about.md
+++ b/about.md
@@ -6,6 +6,12 @@ image: "https://github.com/viktor-shcherb.png?size=600"
 image_alt: "Viktor Shcherbakov on GitHub"
 schema: person
 ---
-{% avatar viktor-shcherb size=240 alt="Picture of Viktor" class="avatar" %}  
+
+<img src="https://github.com/viktor-shcherb.png?size=240"
+     alt="Picture of Viktor"
+     class="avatar"
+     width="240" height="240"
+     loading="lazy"
+     decoding="async">
  
 WIP

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -190,6 +190,6 @@ h6:hover .anchorjs-link::after {
   box-shadow:
     0 2px 6px rgba(0,0,0,.2),   /* soft outer shadow */
     0 1px 3px rgba(0,0,0,.1);   /* subtle inner lift */
-  width: auto;               /* keep natural width */
   max-width: 100%;           /* stay responsive */
+  height: auto;              /* keep aspect ratio when dims set */
 }

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,24 +1,16 @@
 ---
-layout: default 
-permalink: /blog/        # keep the /blog/ URL
+layout: post
+permalink: /blog/
 ---
 
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <!-- Liquid grabs the first post (newest) -->
-    {% assign latest = site.posts | first %}
-    <meta http-equiv="refresh"
-          content="0; url={{ latest.url | relative_url }}">
-    <link rel="canonical"
-          href="{{ latest.url | absolute_url }}">
-    <title>Redirecting to {{ latest.title }}</title>
-  </head>
-  <body>
-    <p>
-      Redirecting to
-      <a href="{{ latest.url | relative_url }}">{{ latest.title }}</a>…
-    </p>
-  </body>
-</html>
+{% assign latest = site.posts | first %}
+<link rel="canonical" href="{{ latest.url | absolute_url }}">
+
+<h1>{{ latest.title }}</h1>
+<p class="post-meta">
+  <time datetime="{{ latest.date | date_to_xmlschema }}">
+    {{ latest.date | date: "%b %-d, %Y" }}
+  </time>
+</p>
+
+{{ latest.content }}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,7 +1,20 @@
 {
   "ci": {
     "collect": {
-      "url": ["https://viktor-shcherb.github.io/"]
+      "url": [
+        "https://viktor-shcherb.github.io/about/",
+        "https://viktor-shcherb.github.io/2025/06/26/Path-to-working-permit-for-Swiss-graduates/",
+        "https://viktor-shcherb.github.io/blog/"
+      ],
+      "settings": {
+        "preset": "mobile",
+        "throttlingMethod": "simulate"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "cumulative-layout-shift": ["error", {"maxNumericValue": 0.12, "aggregationMethod": "optimistic"}]
+      }
     },
     "upload": {
       "target": "temporary-public-storage"


### PR DESCRIPTION
## Summary
- ensure images have dimensions
- show most recent post at `/blog` without redirect
- add a simple `post` layout
- tweak image styles for stability
- tighten Lighthouse CI config

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d34c48cd8833189c58e72876fe15a