### PR TITLE
Fix CLS from icon font

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,9 @@
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap" as="style">
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap"></noscript>
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block" as="style">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block" rel="stylesheet" media="print" onload="this.media='all'">
+<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block"></noscript>
 
 <script>
 (()=>{
@@ -79,7 +79,7 @@
           <button id="theme-toggle"
                   class="theme-btn"
                   aria-label="Toggle colour scheme">
-            <span class="material-symbols-outlined" id="theme-icon" aria-hidden="true"></span>
+            <span class="material-symbols-outlined" id="theme-icon" aria-hidden="true" data-icon></span>
           </button>
         </nav>
 
@@ -92,7 +92,7 @@
         {%- else -%}
           <div class="recent-posts">
             <h2 class="recent-heading">
-              <span class="material-symbols-outlined" aria-hidden="true">article</span>
+              <span class="material-symbols-outlined" aria-hidden="true" data-icon="article"></span>
               Recent&nbsp;posts
             </h2>
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -120,6 +120,12 @@ header,                     /* fallback for plain <header>        */
   transition:background 0.2s;
 }
 
+#theme-icon{
+  font-size:1.25rem;
+  width:1em;
+  display:inline-block;
+}
+
 .theme-btn:hover{
   opacity: 0.75;
 }
@@ -139,6 +145,11 @@ header,                     /* fallback for plain <header>        */
 
 .go-blog a:hover{ text-decoration:underline; }
 .go-blog .material-symbols-outlined{ font-size:1.2em; }
+
+.material-symbols-outlined{
+  display:inline-block;
+  width:1em;
+}
 
 
 a:hover,

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,1 +1,35 @@
-(()=>{const k="prefers-dark",r=document.documentElement,t=document.getElementById("theme-toggle"),e=document.getElementById("theme-icon"),o=window.matchMedia("(prefers-color-scheme: dark)").matches,a=localStorage.getItem(k),d=a?a==="true":o;function n(s){r.dataset.theme=s?"dark":"light",e.textContent=s?"light_mode":"dark_mode"}n(d),t.addEventListener("click",()=>{const s=r.dataset.theme==="dark";n(!s),localStorage.setItem(k,!s)})})();
+(() => {
+  const key = 'prefers-dark';
+  const root = document.documentElement;
+  const toggle = document.getElementById('theme-toggle');
+  const icon = document.getElementById('theme-icon');
+  const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const stored = localStorage.getItem(key);
+  const startDark = stored ? stored === 'true' : prefers;
+  let fontsReady = false;
+
+  function setIcon(isDark) {
+    icon.dataset.icon = isDark ? 'light_mode' : 'dark_mode';
+    if (fontsReady) icon.textContent = icon.dataset.icon;
+  }
+
+  function apply(isDark) {
+    root.dataset.theme = isDark ? 'dark' : 'light';
+    setIcon(isDark);
+  }
+
+  document.fonts.ready.then(() => {
+    fontsReady = true;
+    for (const el of document.querySelectorAll('.material-symbols-outlined[data-icon]')) {
+      el.textContent = el.dataset.icon;
+    }
+  });
+
+  apply(startDark);
+
+  toggle.addEventListener('click', () => {
+    const isDark = root.dataset.theme === 'dark';
+    apply(!isDark);
+    localStorage.setItem(key, !isDark);
+  });
+})();


### PR DESCRIPTION
## Summary
- preload Material Symbols with `display=block` so fallback text doesn't show
- reserve space for icons via CSS
- update JS to insert ligatures only after the font is ready
- keep the icon names in `data-icon` attributes

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d381668148331a8521fe848484bbd