### PR TITLE
Fix mobile blank screen caused by loader

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,24 +19,7 @@
       href="/assets/fonts/material-symbols.css"
       data-turbo-track="reload">
 
-<script>
-const fontsReady = document.fonts.ready;
 
-const cssReady = new Promise(resolve => {
-  const link = document.querySelector('link[href*="style.css"]');
-  if (!link) return resolve();           // should never happen
-  if (link.sheet) return resolve();      // CSS already parsed
-
-  link.addEventListener('load', resolve, { once: true });
-});
-
-Promise.all([fontsReady, cssReady]).then(() => {
-  const l = document.getElementById('app-loader');
-  if (!l) return;
-  l.classList.add('fade');
-  setTimeout(() => l.remove(), 500);     // 0.05 s fade-out
-});
-</script>
 
 <noscript><style>#app-loader{display:none!important}</style></noscript>
 
@@ -197,6 +180,7 @@ document.addEventListener('DOMContentLoaded', function() {
       </footer>
 
       <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
+      <script src="{{ '/assets/js/loader.js' | relative_url }}" defer></script>
     </div>
     <script defer src="{{ '/assets/js/scale.fix.js' | relative_url }}"></script>
     {% if page.layout == 'post' %}

--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -1,0 +1,17 @@
+function hideLoader() {
+  const fontsReady = document.fonts.ready;
+  const cssReady = new Promise(resolve => {
+    const link = document.querySelector('link[href*="style.css"]');
+    if (!link) return resolve();
+    if (link.sheet) return resolve();
+    link.addEventListener('load', resolve, { once: true });
+  });
+  Promise.all([fontsReady, cssReady]).then(() => {
+    const l = document.getElementById('app-loader');
+    if (!l) return;
+    l.classList.add('fade');
+    setTimeout(() => l.remove(), 500);
+  });
+}
+
+document.addEventListener('turbo:load', hideLoader);


### PR DESCRIPTION
## Summary
- remove inline loader script
- add dedicated loader.js handling Turbo navigation

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_686465e9486083319298069565ae7817