### PR TITLE
Add task prerendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# gem "rails"
+gem "github-pages", group: :jekyll_plugins
+gem "faraday-retry"

--- a/algoprep/index.md
+++ b/algoprep/index.md
@@ -172,6 +172,8 @@ Find the source and contribute at [GitHub](https://github.com/viktor-shcherb/vik
   </div>
 </div>
 
+<!-- Contains a summary produced at build time so this page can render
+     without fetching every task JSON file. -->
 <script src="/assets/js/prerendered-tasks.js"></script>
 <script type="module" src="/assets/js/algoprep-list.js"></script>
 <script type="module" src="/assets/js/algoprep-contribute.js"></script>

--- a/algoprep/index.md
+++ b/algoprep/index.md
@@ -172,5 +172,6 @@ Find the source and contribute at [GitHub](https://github.com/viktor-shcherb/vik
   </div>
 </div>
 
+<script src="/assets/js/prerendered-tasks.js"></script>
 <script type="module" src="/assets/js/algoprep-list.js"></script>
 <script type="module" src="/assets/js/algoprep-contribute.js"></script>

--- a/assets/js/algoprep-list.js
+++ b/assets/js/algoprep-list.js
@@ -1,10 +1,14 @@
+// Build the list of available tasks.  If the prerender script has
+// produced metadata for a task we use it instead of fetching the JSON
+// file, cutting down on network requests.
 export async function renderTaskList(taskFiles) {
   const list = document.getElementById('task-list');
   if (!list) return;
 
   list.innerHTML = '<ul id="task-list-ul"><li>Loading tasks...</li></ul>';
 
-  // Fetch all JSON files in parallel, preferring pre-rendered data
+  // Fetch all JSON files in parallel, but skip the network step when
+  // the prerender script has already supplied the metadata.
   const tasks = await Promise.all(
     taskFiles.map(async (slug) => {
       if (window.preRenderedTasks && window.preRenderedTasks[slug]) {
@@ -26,6 +30,7 @@ export async function renderTaskList(taskFiles) {
     .filter(Boolean)
     .map((task) => {
       const pre = window.preRenderedTasks && window.preRenderedTasks[task.slug];
+      // Use the static page when available so the user loads HTML directly.
       const url = pre
         ? `/algoprep/task/${task.slug}/`
         : `/algoprep/task?id=${encodeURIComponent(task.slug)}`;

--- a/assets/js/prerendered-tasks.js
+++ b/assets/js/prerendered-tasks.js
@@ -1,1 +1,3 @@
+// Populated by `scripts/prerender-tasks.mjs`.  The list page reads this
+// object to avoid fetching every task JSON during startup.
 window.preRenderedTasks = window.preRenderedTasks || {};

--- a/assets/js/prerendered-tasks.js
+++ b/assets/js/prerendered-tasks.js
@@ -1,0 +1,1 @@
+window.preRenderedTasks = window.preRenderedTasks || {};

--- a/assets/js/task-page.js
+++ b/assets/js/task-page.js
@@ -1,3 +1,6 @@
+// Page controller for an individual algorithm task.
+// It can operate on either a pre-rendered task object embedded by the
+// build step or a JSON file fetched at runtime.
 import { initTabSwitcher }  from '/assets/js/tab-switcher.js';
 import { loadTask }         from '/assets/js/task-loader.js';
 import { renderTask,
@@ -10,18 +13,23 @@ import { setupEditor,
 let currentTask, editorReady = false;
 
 async function renderPage() {
+  // When the page was created by the prerender script it defines
+  // `window.PRE_RENDERED_TASK` to avoid fetching the JSON again.
   const pre  = window.PRE_RENDERED_TASK;
   const slug = pre?.slug || new URLSearchParams(location.search).get('id');
   if (!slug) return;
 
-  // 1. make sure the placeholders exist in the live DOM
+  // 1. Ensure the layout slots exist.  This runs here so the same
+  //    templates can also be injected by the prerender step.
   ensureTaskSkeleton();
 
-  // 2. fetch the task JSON and render it into those placeholders
+  // 2. Either reuse the embedded object or fetch the task JSON and
+  //    render it into the skeleton.
   currentTask = pre || await loadTask(slug);
   renderTask(currentTask, document);
 
-  // 3. normal boot-strapping
+  // 3. Continue with the interactive features once the static
+  //    content is in place.
   initTabSwitcher(document);
   updateEditorTheme();
 }

--- a/assets/js/task-page.js
+++ b/assets/js/task-page.js
@@ -10,14 +10,15 @@ import { setupEditor,
 let currentTask, editorReady = false;
 
 async function renderPage() {
-  const slug = new URLSearchParams(location.search).get('id');
+  const pre  = window.PRE_RENDERED_TASK;
+  const slug = pre?.slug || new URLSearchParams(location.search).get('id');
   if (!slug) return;
 
   // 1. make sure the placeholders exist in the live DOM
   ensureTaskSkeleton();
 
   // 2. fetch the task JSON and render it into those placeholders
-  currentTask = await loadTask(slug);
+  currentTask = pre || await loadTask(slug);
   renderTask(currentTask, document);
 
   // 3. normal boot-strapping

--- a/assets/js/task-render-core.js
+++ b/assets/js/task-render-core.js
@@ -1,3 +1,14 @@
+/**
+ * DOM helpers shared by the runtime and the prerender script.
+ * They contain no references to browser-only APIs so that jsdom can
+ * evaluate them when generating static pages.
+ */
+
+/**
+ * Ensure the task placeholders are present.
+ * This runs in both Node (via jsdom) and the browser so that the
+ * prerender script and runtime share exactly the same markup.
+ */
 export function ensureTaskSkeleton(doc) {
   if (doc.querySelector('.task-title')) return;
   const headTpl = doc.getElementById('task-head-template');
@@ -9,6 +20,11 @@ export function ensureTaskSkeleton(doc) {
   panel.appendChild(bodyTpl.content.cloneNode(true));
 }
 
+/**
+ * Build a minimal Python function stub from a signature object.
+ * Sharing this logic keeps editor hints identical between prerender
+ * and client side.
+ */
 export function signatureToString(sig) {
   if (!sig?.name) return '';
   const args = (sig.args || [])
@@ -19,6 +35,11 @@ export function signatureToString(sig) {
   return `def ${sig.name}(${args})${arrow}:\n    pass`;
 }
 
+/**
+ * Render a couple of example cards for display below the task
+ * description.  These examples are static HTML so they can be
+ * embedded during prerendering and later enhanced in the browser.
+ */
 export function buildExamples(tests = [], signature = {}) {
   if (!tests.length) return '';
   const esc = s =>
@@ -60,6 +81,10 @@ export function buildExamples(tests = [], signature = {}) {
   );
 }
 
+/**
+ * Fill the task placeholders with data.  `parseMarkdown` is supplied by
+ * the caller so we can use the same function in Node and the browser.
+ */
 export function populateTaskDOM(task, container, parseMarkdown) {
   const els = {
     title: container.querySelector('.task-title'),

--- a/assets/js/task-render-core.js
+++ b/assets/js/task-render-core.js
@@ -1,0 +1,87 @@
+export function ensureTaskSkeleton(doc) {
+  if (doc.querySelector('.task-title')) return;
+  const headTpl = doc.getElementById('task-head-template');
+  const bodyTpl = doc.getElementById('task-body-template');
+  if (!headTpl || !bodyTpl) return;
+  const tabs = doc.getElementById('task-tabs');
+  const panel = doc.getElementById('panel-desc');
+  tabs.parentNode.insertBefore(headTpl.content.cloneNode(true), tabs);
+  panel.appendChild(bodyTpl.content.cloneNode(true));
+}
+
+export function signatureToString(sig) {
+  if (!sig?.name) return '';
+  const args = (sig.args || [])
+    .map(a => a.name + (a.type ? `: ${a.type}` : ''))
+    .join(', ');
+  const ret = sig.return_type || sig.returnType || '';
+  const arrow = ret ? ` -> ${ret}` : '';
+  return `def ${sig.name}(${args})${arrow}:\n    pass`;
+}
+
+export function buildExamples(tests = [], signature = {}) {
+  if (!tests.length) return '';
+  const esc = s =>
+    String(s).replace(/[&<>"']/g, m => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[m]));
+  const fn = signature.name ?? 'fn';
+  return (
+    '<h2>Examples</h2>\n' +
+    tests.slice(0, 3).map((test, i) => {
+      const argLines = Object.entries(test.args ?? {})
+        .map(([k, v]) => `  ${k}=${JSON.stringify(v)}`)
+        .join(',\n');
+      const call = argLines ? `${fn}(\n${argLines}\n)` : `${fn}()`;
+      const callLine = 'return' in test ? `${call} == ${JSON.stringify(test.return)}` : call;
+      const html = [`<div class="example-card">`,
+        `<div class="io-block call" aria-labelledby="lbl-call-${i}">`,
+        `<span id="lbl-call-${i}" class="io-label">Function call</span>`,
+        `<pre id="call-${i}"><code class="language-python-codemirror">${esc(callLine)}</code></pre>`,
+        `</div>`];
+      if (test.stdin) {
+        html.push(`<div class="io-block input" aria-labelledby="lbl-stdin-${i}">`,
+          `<span id="lbl-stdin-${i}" class="io-label">stdin</span>`,
+          `<div id="stdin-${i}" class="io-surface">${esc(test.stdin)}</div>`,
+          `</div>`);
+      }
+      if ('stdout' in test) {
+        const out = typeof test.stdout === 'object'
+          ? JSON.stringify(test.stdout, null, 2)
+          : test.stdout;
+        html.push(`<div class="io-block output" aria-labelledby="lbl-stdout-${i}">`,
+          `<span id="lbl-stdout-${i}" class="io-label">stdout&nbsp;(expected)</span>`,
+          `<div id="stdout-${i}" class="io-surface">${esc(out)}</div>`,
+          `</div>`);
+      }
+      html.push('</div>');
+      return html.join('');
+    }).join('')
+  );
+}
+
+export function populateTaskDOM(task, container, parseMarkdown) {
+  const els = {
+    title: container.querySelector('.task-title'),
+    desc: container.querySelector('.task-description'),
+    signature: container.querySelector('.task-signature'),
+    examples: container.querySelector('.task-examples'),
+    contributor: container.querySelector('.task-contributor')
+  };
+  if (els.title) els.title.textContent = task.title ?? 'Untitled task';
+  if (els.desc) els.desc.innerHTML = parseMarkdown ? parseMarkdown(task.description ?? '') : (task.description ?? '');
+  if (els.signature) {
+    els.signature.innerHTML = task.signature
+      ? `<pre><code class="language-python-codemirror">${signatureToString(task.signature)}</code></pre>`
+      : '';
+  }
+  if (els.examples) {
+    els.examples.innerHTML = buildExamples(task.tests, task.signature);
+    els.examples.style.display = task.tests?.length ? '' : 'none';
+  }
+  if (els.contributor) {
+    els.contributor.innerHTML = task.contributor
+      ? `Contributed by <a href="${task.contributor.github}" target="_blank">${task.contributor.name}</a>`
+      : '';
+  }
+}

--- a/assets/js/task-render.js
+++ b/assets/js/task-render.js
@@ -1,3 +1,7 @@
+// Browser-specific wrapper around the core DOM helpers.
+// This module wires in Marked and CodeMirror, leaving the generic
+// DOM manipulation code reusable from Node during prerendering.
+
 import { marked } from 'https://cdn.jsdelivr.net/npm/marked/+esm';
 import { renderReadOnlyCodeBlocks } from './editor.js';
 import {
@@ -9,10 +13,15 @@ import {
 export { signatureToString } from './task-render-core.js';
 
 export function ensureTaskSkeleton() {
+  // Keep a single implementation for injecting templates.
+  // In the browser we simply delegate to the shared helper.
   ensureDocSkeleton(document);
 }
 
 export function renderTask(task, container) {
+  // Fill the placeholders using the shared logic and then
+  // activate CodeMirror so the code samples look the same as
+  // those built dynamically.
   populateTaskDOM(task, container, marked.parse);
   renderReadOnlyCodeBlocks();
 }

--- a/assets/js/task-render.js
+++ b/assets/js/task-render.js
@@ -1,135 +1,18 @@
 import { marked } from 'https://cdn.jsdelivr.net/npm/marked/+esm';
-
 import { renderReadOnlyCodeBlocks } from './editor.js';
+import {
+  ensureTaskSkeleton as ensureDocSkeleton,
+  signatureToString,
+  populateTaskDOM,
+} from './task-render-core.js';
 
-/* -----------------------------------------------------------
-   Inject task skeleton if it is not in the live DOM yet
------------------------------------------------------------ */
+export { signatureToString } from './task-render-core.js';
+
 export function ensureTaskSkeleton() {
-  if (document.querySelector('.task-title')) return;          // already done
-
-  const headTpl = document.getElementById('task-head-template');
-  const bodyTpl = document.getElementById('task-body-template');
-  if (!headTpl || !bodyTpl) return;
-
-  /* ---- 1. head goes ABOVE the switcher ------------------------- */
-  const head = headTpl.content.cloneNode(true);
-  const tabs = document.getElementById('task-tabs');          // <div class="tab-switcher">
-  tabs.parentNode.insertBefore(head, tabs);
-
-  /* ---- 2. body stays inside the description panel -------------- */
-  const body = bodyTpl.content.cloneNode(true);
-  const panel = document.getElementById('panel-desc');
-  panel.appendChild(body);
+  ensureDocSkeleton(document);
 }
 
-
-export function signatureToString(sig) {
-  if (!sig?.name) return '';
-
-  /*-- arguments --*/
-  const args = (sig.args || [])
-    .map(a => a.name + (a.type ? `: ${a.type}` : ''))
-    .join(', ');
-
-  /*-- optional return annotation --*/
-  const ret = sig.return_type || sig.returnType || '';
-  const arrow = ret ? ` -> ${ret}` : '';
-
-  return `def ${sig.name}(${args})${arrow}:\n    pass`;
-}
-
-/**
- * Render up to three tests as mini-cards.
- * @param {Array}  tests      — task.tests
- * @param {Object} signature  — task.signature  (needs .name)
- */
-function buildExamples(tests = [], signature = {}) {
-  if (!tests.length) return '';
-
-  const esc = s =>
-    String(s).replace(/[&<>"']/g, m =>
-      ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[m]));
-
-  const fn = signature.name ?? 'fn';
-
-  return (
-    '<h2>Examples</h2>\n' +
-    tests.slice(0, 3).map((test, i) => {
-      /* -------- build the function-call line -------------------- */
-      const argLines = Object.entries(test.args ?? {})
-        .map(([k, v]) => `  ${k}=${JSON.stringify(v)}`)
-        .join(',\n');
-
-      const call = argLines ? `${fn}(\n${argLines}\n)` : `${fn}()`;
-      const callLine =
-        'return' in test ? `${call} == ${JSON.stringify(test.return)}` : call;
-
-      /* -------- assemble one card ------------------------------- */
-      const html = [`
-        <div class="example-card">
-
-          <div class="io-block call" aria-labelledby="lbl-call-${i}">
-            <span id="lbl-call-${i}" class="io-label">Function call</span>
-            <pre id="call-${i}">
-              <code class="language-python-codemirror">${esc(callLine)}</code>
-            </pre>
-          </div>`];
-
-      if (test.stdin) {
-        html.push(`
-          <div class="io-block input" aria-labelledby="lbl-stdin-${i}">
-            <span id="lbl-stdin-${i}" class="io-label">stdin</span>
-            <div id="stdin-${i}" class="io-surface">${esc(test.stdin)}</div>
-          </div>`);
-      }
-
-      if ('stdout' in test) {
-        const out =
-          typeof test.stdout === 'object'
-            ? JSON.stringify(test.stdout, null, 2)
-            : test.stdout;
-
-        html.push(`
-          <div class="io-block output" aria-labelledby="lbl-stdout-${i}">
-            <span id="lbl-stdout-${i}" class="io-label">stdout&nbsp;(expected)</span>
-            <div id="stdout-${i}" class="io-surface">${esc(out)}</div>
-          </div>`);
-      }
-
-      html.push('</div>'); // close .example-card
-      return html.join('');
-    }).join('')
-  );
-}
-
-export function renderTask(task, container){
-  /* container should have the five placeholders below */
-  const els = {
-    title:       container.querySelector('.task-title'),
-    desc:        container.querySelector('.task-description'),
-    signature:   container.querySelector('.task-signature'),
-    examples:    container.querySelector('.task-examples'),
-    contributor: container.querySelector('.task-contributor')
-  };
-
-  if (els.title)  els.title.textContent = task.title ?? 'Untitled task';
-  if (els.desc)   els.desc.innerHTML    = marked.parse(task.description ?? '');
-  if (els.signature){
-    els.signature.innerHTML = task.signature ?
-        `<pre><code class="language-python-codemirror">${signatureToString(task.signature)}</code></pre>`
-        : '';
-  }
-  if (els.examples){
-    els.examples.innerHTML = buildExamples(task.tests, task.signature);
-    els.examples.style.display = task.tests?.length ? '' : 'none';
-  }
-  if (els.contributor){
-    els.contributor.innerHTML = task.contributor ?
-      `Contributed by <a href="${task.contributor.github}" target="_blank">${task.contributor.name}</a>`
-      : '';
-  }
-
-  /* let Prism/CodeMirror read-only renderer update colours */
+export function renderTask(task, container) {
+  populateTaskDOM(task, container, marked.parse);
   renderReadOnlyCodeBlocks();
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "dependencies": {
+    "jsdom": "^24.0.0",
+    "marked": "^9.0.0"
+  }
+}

--- a/scripts/prerender-tasks.mjs
+++ b/scripts/prerender-tasks.mjs
@@ -1,111 +1,38 @@
-import {readFile, writeFile, mkdir, readdir} from 'fs/promises';
-import {dirname, join} from 'path';
-import {JSDOM} from 'jsdom';
-import {marked} from 'marked';
+import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
+import { dirname, join } from 'path';
+import { JSDOM } from 'jsdom';
+import { marked } from 'marked';
+import { ensureTaskSkeleton, populateTaskDOM } from '../assets/js/task-render-core.js';
 
 const SITE_DIR = '_site';
 const TASK_TEMPLATE = join(SITE_DIR, 'algoprep', 'task.html');
 const TASK_JSON_DIR = 'algoprep';
 
-function ensureTaskSkeleton(doc){
-  if (doc.querySelector('.task-title')) return;
-  const headTpl = doc.getElementById('task-head-template');
-  const bodyTpl = doc.getElementById('task-body-template');
-  if (!headTpl || !bodyTpl) return;
-  const tabs = doc.getElementById('task-tabs');
-  const panel = doc.getElementById('panel-desc');
-  tabs.parentNode.insertBefore(headTpl.content.cloneNode(true), tabs);
-  panel.appendChild(bodyTpl.content.cloneNode(true));
-}
-
-function signatureToString(sig){
-  if (!sig?.name) return '';
-  const args = (sig.args || [])
-    .map(a => a.name + (a.type ? `: ${a.type}` : ''))
-    .join(', ');
-  const ret = sig.return_type || sig.returnType || '';
-  const arrow = ret ? ` -> ${ret}` : '';
-  return `def ${sig.name}(${args})${arrow}:\n    pass`;
-}
-
-function buildExamples(tests = [], signature = {}){
-  if (!tests.length) return '';
-  const esc = s => String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
-  const fn = signature.name ?? 'fn';
-  return '<h2>Examples</h2>\n' + tests.slice(0,3).map((test,i)=>{
-    const argLines = Object.entries(test.args ?? {})
-      .map(([k,v])=>`  ${k}=${JSON.stringify(v)}`)
-      .join(',\n');
-    const call = argLines ? `${fn}(\n${argLines}\n)` : `${fn}()`;
-    const callLine = 'return' in test ? `${call} == ${JSON.stringify(test.return)}` : call;
-    const html = [`<div class="example-card">`,
-      `<div class="io-block call" aria-labelledby="lbl-call-${i}">`,
-      `<span id="lbl-call-${i}" class="io-label">Function call</span>`,
-      `<pre id="call-${i}"><code class="language-python-codemirror">${esc(callLine)}</code></pre>`,
-      `</div>`];
-    if (test.stdin){
-      html.push(`<div class="io-block input" aria-labelledby="lbl-stdin-${i}">`,
-        `<span id="lbl-stdin-${i}" class="io-label">stdin</span>`,
-        `<div id="stdin-${i}" class="io-surface">${esc(test.stdin)}</div>`,
-        `</div>`);
-    }
-    if ('stdout' in test){
-      const out = typeof test.stdout === 'object' ? JSON.stringify(test.stdout, null, 2) : test.stdout;
-      html.push(`<div class="io-block output" aria-labelledby="lbl-stdout-${i}">`,
-        `<span id="lbl-stdout-${i}" class="io-label">stdout&nbsp;(expected)</span>`,
-        `<div id="stdout-${i}" class="io-surface">${esc(out)}</div>`,
-        `</div>`);
-    }
-    html.push('</div>');
-    return html.join('');
-  }).join('');
-}
-
-function renderTask(task, doc){
-  const container = doc;
-  const els = {
-    title: container.querySelector('.task-title'),
-    desc: container.querySelector('.task-description'),
-    signature: container.querySelector('.task-signature'),
-    examples: container.querySelector('.task-examples'),
-    contributor: container.querySelector('.task-contributor')
-  };
-  if (els.title) els.title.textContent = task.title ?? 'Untitled task';
-  if (els.desc) els.desc.innerHTML = marked.parse(task.description ?? '');
-  if (els.signature){
-    els.signature.innerHTML = task.signature ? `<pre><code class="language-python-codemirror">${signatureToString(task.signature)}</code></pre>` : '';
-  }
-  if (els.examples){
-    els.examples.innerHTML = buildExamples(task.tests, task.signature);
-    els.examples.style.display = task.tests?.length ? '' : 'none';
-  }
-  if (els.contributor){
-    els.contributor.innerHTML = task.contributor ? `Contributed by <a href="${task.contributor.github}" target="_blank">${task.contributor.name}</a>` : '';
-  }
-}
-
-async function main(){
+async function main() {
   const templateHtml = await readFile(TASK_TEMPLATE, 'utf8');
   const taskFiles = (await readdir(TASK_JSON_DIR)).filter(f => f.endsWith('.json'));
   const summary = {};
-  for (const file of taskFiles){
+  for (const file of taskFiles) {
     const slug = file.replace(/\.json$/, '');
     const json = JSON.parse(await readFile(join(TASK_JSON_DIR, file), 'utf8'));
     const dom = new JSDOM(templateHtml);
-    const {document} = dom.window;
+    const { document } = dom.window;
     ensureTaskSkeleton(document);
-    renderTask(json, document);
+    populateTaskDOM(json, document, marked.parse);
     const script = document.createElement('script');
-    script.textContent = `window.PRE_RENDERED_TASK = ${JSON.stringify({slug, ...json})}`;
+    script.textContent = `window.PRE_RENDERED_TASK = ${JSON.stringify({ slug, ...json })}`;
     document.body.appendChild(script);
     const outDir = join(SITE_DIR, 'algoprep', 'task', slug);
-    await mkdir(outDir, {recursive:true});
+    await mkdir(outDir, { recursive: true });
     await writeFile(join(outDir, 'index.html'), dom.serialize());
-    summary[slug] = {title: json.title, contributor: json.contributor};
+    summary[slug] = { title: json.title, contributor: json.contributor };
   }
   const summaryPath = join(SITE_DIR, 'assets', 'js', 'prerendered-tasks.js');
-  await mkdir(dirname(summaryPath), {recursive:true});
+  await mkdir(dirname(summaryPath), { recursive: true });
   await writeFile(summaryPath, `window.preRenderedTasks = ${JSON.stringify(summary)};`);
 }
 
-main().catch(err => { console.error(err); process.exit(1); });
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/prerender-tasks.mjs
+++ b/scripts/prerender-tasks.mjs
@@ -1,0 +1,111 @@
+import {readFile, writeFile, mkdir, readdir} from 'fs/promises';
+import {dirname, join} from 'path';
+import {JSDOM} from 'jsdom';
+import {marked} from 'marked';
+
+const SITE_DIR = '_site';
+const TASK_TEMPLATE = join(SITE_DIR, 'algoprep', 'task.html');
+const TASK_JSON_DIR = 'algoprep';
+
+function ensureTaskSkeleton(doc){
+  if (doc.querySelector('.task-title')) return;
+  const headTpl = doc.getElementById('task-head-template');
+  const bodyTpl = doc.getElementById('task-body-template');
+  if (!headTpl || !bodyTpl) return;
+  const tabs = doc.getElementById('task-tabs');
+  const panel = doc.getElementById('panel-desc');
+  tabs.parentNode.insertBefore(headTpl.content.cloneNode(true), tabs);
+  panel.appendChild(bodyTpl.content.cloneNode(true));
+}
+
+function signatureToString(sig){
+  if (!sig?.name) return '';
+  const args = (sig.args || [])
+    .map(a => a.name + (a.type ? `: ${a.type}` : ''))
+    .join(', ');
+  const ret = sig.return_type || sig.returnType || '';
+  const arrow = ret ? ` -> ${ret}` : '';
+  return `def ${sig.name}(${args})${arrow}:\n    pass`;
+}
+
+function buildExamples(tests = [], signature = {}){
+  if (!tests.length) return '';
+  const esc = s => String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+  const fn = signature.name ?? 'fn';
+  return '<h2>Examples</h2>\n' + tests.slice(0,3).map((test,i)=>{
+    const argLines = Object.entries(test.args ?? {})
+      .map(([k,v])=>`  ${k}=${JSON.stringify(v)}`)
+      .join(',\n');
+    const call = argLines ? `${fn}(\n${argLines}\n)` : `${fn}()`;
+    const callLine = 'return' in test ? `${call} == ${JSON.stringify(test.return)}` : call;
+    const html = [`<div class="example-card">`,
+      `<div class="io-block call" aria-labelledby="lbl-call-${i}">`,
+      `<span id="lbl-call-${i}" class="io-label">Function call</span>`,
+      `<pre id="call-${i}"><code class="language-python-codemirror">${esc(callLine)}</code></pre>`,
+      `</div>`];
+    if (test.stdin){
+      html.push(`<div class="io-block input" aria-labelledby="lbl-stdin-${i}">`,
+        `<span id="lbl-stdin-${i}" class="io-label">stdin</span>`,
+        `<div id="stdin-${i}" class="io-surface">${esc(test.stdin)}</div>`,
+        `</div>`);
+    }
+    if ('stdout' in test){
+      const out = typeof test.stdout === 'object' ? JSON.stringify(test.stdout, null, 2) : test.stdout;
+      html.push(`<div class="io-block output" aria-labelledby="lbl-stdout-${i}">`,
+        `<span id="lbl-stdout-${i}" class="io-label">stdout&nbsp;(expected)</span>`,
+        `<div id="stdout-${i}" class="io-surface">${esc(out)}</div>`,
+        `</div>`);
+    }
+    html.push('</div>');
+    return html.join('');
+  }).join('');
+}
+
+function renderTask(task, doc){
+  const container = doc;
+  const els = {
+    title: container.querySelector('.task-title'),
+    desc: container.querySelector('.task-description'),
+    signature: container.querySelector('.task-signature'),
+    examples: container.querySelector('.task-examples'),
+    contributor: container.querySelector('.task-contributor')
+  };
+  if (els.title) els.title.textContent = task.title ?? 'Untitled task';
+  if (els.desc) els.desc.innerHTML = marked.parse(task.description ?? '');
+  if (els.signature){
+    els.signature.innerHTML = task.signature ? `<pre><code class="language-python-codemirror">${signatureToString(task.signature)}</code></pre>` : '';
+  }
+  if (els.examples){
+    els.examples.innerHTML = buildExamples(task.tests, task.signature);
+    els.examples.style.display = task.tests?.length ? '' : 'none';
+  }
+  if (els.contributor){
+    els.contributor.innerHTML = task.contributor ? `Contributed by <a href="${task.contributor.github}" target="_blank">${task.contributor.name}</a>` : '';
+  }
+}
+
+async function main(){
+  const templateHtml = await readFile(TASK_TEMPLATE, 'utf8');
+  const taskFiles = (await readdir(TASK_JSON_DIR)).filter(f => f.endsWith('.json'));
+  const summary = {};
+  for (const file of taskFiles){
+    const slug = file.replace(/\.json$/, '');
+    const json = JSON.parse(await readFile(join(TASK_JSON_DIR, file), 'utf8'));
+    const dom = new JSDOM(templateHtml);
+    const {document} = dom.window;
+    ensureTaskSkeleton(document);
+    renderTask(json, document);
+    const script = document.createElement('script');
+    script.textContent = `window.PRE_RENDERED_TASK = ${JSON.stringify({slug, ...json})}`;
+    document.body.appendChild(script);
+    const outDir = join(SITE_DIR, 'algoprep', 'task', slug);
+    await mkdir(outDir, {recursive:true});
+    await writeFile(join(outDir, 'index.html'), dom.serialize());
+    summary[slug] = {title: json.title, contributor: json.contributor};
+  }
+  const summaryPath = join(SITE_DIR, 'assets', 'js', 'prerendered-tasks.js');
+  await mkdir(dirname(summaryPath), {recursive:true});
+  await writeFile(summaryPath, `window.preRenderedTasks = ${JSON.stringify(summary)};`);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/prerender-tasks.mjs
+++ b/scripts/prerender-tasks.mjs
@@ -1,3 +1,10 @@
+/**
+ * Build-time script that expands each algorithm task JSON into a static
+ * HTML page under `_site/algoprep/task/`.  By doing this after Jekyll
+ * has built the site we keep all source files untouched while reducing
+ * runtime work in the browser.
+ */
+
 import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import { dirname, join } from 'path';
 import { JSDOM } from 'jsdom';
@@ -9,16 +16,26 @@ const TASK_TEMPLATE = join(SITE_DIR, 'algoprep', 'task.html');
 const TASK_JSON_DIR = 'algoprep';
 
 async function main() {
+  // Jekyll already produced `task.html` with the layout and scripts.
+  // We load that file once and reuse it as a DOM template for every
+  // algorithm task.
   const templateHtml = await readFile(TASK_TEMPLATE, 'utf8');
+
+  // Collect all task files and prepare a summary object that the list
+  // page will later consume instead of fetching JSON.
   const taskFiles = (await readdir(TASK_JSON_DIR)).filter(f => f.endsWith('.json'));
   const summary = {};
   for (const file of taskFiles) {
     const slug = file.replace(/\.json$/, '');
     const json = JSON.parse(await readFile(join(TASK_JSON_DIR, file), 'utf8'));
+    // Start from the template each time so every page has the same
+    // structure as the dynamic one.
     const dom = new JSDOM(templateHtml);
     const { document } = dom.window;
+    // Insert the placeholders and populate them with the task data.
     ensureTaskSkeleton(document);
     populateTaskDOM(json, document, marked.parse);
+    // Embed the task object so `task-page.js` can skip the fetch.
     const script = document.createElement('script');
     script.textContent = `window.PRE_RENDERED_TASK = ${JSON.stringify({ slug, ...json })}`;
     document.body.appendChild(script);
@@ -27,6 +44,7 @@ async function main() {
     await writeFile(join(outDir, 'index.html'), dom.serialize());
     summary[slug] = { title: json.title, contributor: json.contributor };
   }
+  // Save the summary so the list page can render without extra requests.
   const summaryPath = join(SITE_DIR, 'assets', 'js', 'prerendered-tasks.js');
   await mkdir(dirname(summaryPath), { recursive: true });
   await writeFile(summaryPath, `window.preRenderedTasks = ${JSON.stringify(summary)};`);

--- a/scripts/prerender-tasks.mjs
+++ b/scripts/prerender-tasks.mjs
@@ -12,7 +12,7 @@ import { marked } from 'marked';
 import { ensureTaskSkeleton, populateTaskDOM } from '../assets/js/task-render-core.js';
 
 const SITE_DIR = '_site';
-const TASK_TEMPLATE = join(SITE_DIR, 'algoprep', 'task.html');
+const TASK_TEMPLATE = join(SITE_DIR, 'algoprep', 'task', 'index.html');
 const TASK_JSON_DIR = 'algoprep';
 
 async function main() {


### PR DESCRIPTION
## Summary
- generate static task pages with `scripts/prerender-tasks.mjs`
- record prerendered tasks in `assets/js/prerendered-tasks.js`
- load prerendered tasks on the list and task pages
- wire prerender data into `algoprep/index.md`
- declare jsdom and marked dependencies

## Testing
- `node scripts/prerender-tasks.mjs` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_687639b44e1c83318e681289ca37e124