### PR TITLE
Add GitHub Actions for task automation

### DIFF
--- a/.github/workflows/add-task.yml
+++ b/.github/workflows/add-task.yml
@@ -1,0 +1,63 @@
+name: Add approved task
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  add-task:
+    if: github.event.label.name == 'approved task'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v7
+        id: extract
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const fences = [...body.matchAll(/```json\s+([\s\S]*?)```/g)];
+            function looksLikeTask(o){
+              return o && typeof o === 'object' && 'title' in o && 'description' in o && Array.isArray(o.tests);
+            }
+            let task;
+            for(const m of fences){
+              try{
+                const obj = JSON.parse(m[1]);
+                if(looksLikeTask(obj)){ task = obj; break; }
+              }catch{ }
+            }
+            if(!task) core.setFailed('No valid task JSON found');
+            const slug = task.title.trim().toLowerCase()
+              .replace(/[^a-z0-9\s-]/g, '')
+              .replace(/\s+/g, '-');
+            const fs = require('fs');
+            const path = `algoprep/${slug}.json`;
+            fs.writeFileSync(path, JSON.stringify(task, null, 2));
+            core.setOutput('slug', slug);
+      - name: Commit task file
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add algoprep/${{ steps.extract.outputs.slug }}.json
+          git commit -m "Add task: ${{ steps.extract.outputs.slug }} (closes #${{ github.event.issue.number }})"
+          git push
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const slug = '${{ steps.extract.outputs.slug }}';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Your task has been added and is live at:\nhttps://viktor-shcherb.github.io/algoprep/task/${slug}/`
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed'
+            });

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy Site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: bundle install --jobs 4 --retry 3 --deployment
+      - run: npm ci
+      - run: bundle exec jekyll build
+      - run: node scripts/prerender-tasks.mjs
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: _site
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- add workflow to commit approved tasks on issue labeling
- build and deploy site on pushes to `main`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6876a6bf289083318b97574ef338ff61