### PR TITLE
Fix per-task editor state and pyodide loading

### DIFF
--- a/assets/js/task-page.js
+++ b/assets/js/task-page.js
@@ -42,7 +42,7 @@ document.addEventListener('themechange', updateEditorTheme);
 
 document.addEventListener('tabshown', async ({ detail }) => {
   if (detail.panel.id !== 'panel-code' || editorReady) return;
-  setupEditor(signatureToString(currentTask.signature));
+  setupEditor(signatureToString(currentTask.signature), currentTask.slug);
   setupRunner();
   editorReady = true;
 });


### PR DESCRIPTION
## Summary
- store editor contents under a per-task key
- fall back to dynamically load Pyodide if the CDN script didn't execute
- pass task slug to editor setup so each task restores its own state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877bef261348331867e9a4814012179