### PR TITLE
Align contribute button with tasks header

### DIFF
--- a/algoprep/index.md
+++ b/algoprep/index.md
@@ -15,7 +15,7 @@ Find the source and contribute at [GitHub](https://github.com/viktor-shcherb/vik
 
 <hr>
 
-<div class="tasks-header">
+<div class="available-tasks-header">
   <h2 id="available-tasks">Available Tasks</h2>
   <button id="contribute-btn" class="contribute-btn">
     Contribute new task

--- a/algoprep/index.md
+++ b/algoprep/index.md
@@ -15,7 +15,12 @@ Find the source and contribute at [GitHub](https://github.com/viktor-shcherb/vik
 
 <hr>
 
-## Available Tasks
+<div class="tasks-header">
+  <h2 id="available-tasks">Available Tasks</h2>
+  <button id="contribute-btn" class="contribute-btn">
+    Contribute new task
+  </button>
+</div>
 
 <ul id="task-list" style="margin-top:2em;"><li>Loading tasks...</li></ul>
 
@@ -27,13 +32,8 @@ Find the source and contribute at [GitHub](https://github.com/viktor-shcherb/vik
       "{{ file.name | replace: '.json', '' }}"{% unless forloop.last %},{% endunless %}
     {% endfor %}
   ];
-</script>
 
-<div style="text-align:center; margin:3em 0;">
-  <button id="contribute-btn" class="contribute-btn">
-    Contribute new task
-  </button>
-</div>
+</script>
 
 {% include contribute-modal.html %}
 

--- a/assets/css/_components.scss
+++ b/assets/css/_components.scss
@@ -249,6 +249,12 @@ pre code.language-io-codemirror {
   padding:.45em 1.1em;
 }
 
+.tasks-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
 /* Edit button shown on task pages */
 .edit-task-btn {
   @extend %btn-base;

--- a/assets/css/_components.scss
+++ b/assets/css/_components.scss
@@ -249,10 +249,16 @@ pre code.language-io-codemirror {
   padding:.45em 1.1em;
 }
 
-.tasks-header {
+.available-tasks-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: flex-end;    /* bottom‐align each item */
+}
+
+/* nuke default bottom‐margins so they don’t “sit” at different heights */
+.available-tasks-header h2,
+.available-tasks-header button {
+  margin: 0;
 }
 
 /* Edit button shown on task pages */
@@ -275,6 +281,11 @@ pre code.language-io-codemirror {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+/* sync the default margins so both bottoms actually meet */
+.task-header .task-title,
+.task-header .edit-task-btn {
+  margin: 0.5em;
 }
 
 .task-header .edit-task-btn {


### PR DESCRIPTION
## Summary
- place the contribute button next to the "Available Tasks" header
- add a `.tasks-header` rule for layout

## Testing
- `node scripts/prerender-tasks.mjs` *(fails: ENOENT because `_site` build artifacts missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877cd9f5bd8833188732aee5af99ccd