### PR TITLE
Add copy button to code blocks

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -121,3 +121,6 @@ code {
   vertical-align:middle;
   margin-right: .5em;
 }
+
+pre.copy-wrap{position:relative;}
+.copy-btn{position:absolute;top:.25em;right:.25em;background:none;border:none;color:var(--accent);cursor:pointer;padding:.2em;}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,6 +51,7 @@
     <!-- shared JS -->
     <script type="module" src="/assets/js/main.js" defer></script>
     <script type="module" src="/assets/js/theme-toggle.js"></script>
+    <script type="module" src="/assets/js/copy-code.js" defer></script>
 
     <!-- page-specific JS -->
     {% if page.layout == 'post' %}

--- a/assets/css/_components.scss
+++ b/assets/css/_components.scss
@@ -800,3 +800,20 @@ button:hover{
   opacity:.8;
 }
 
+/* Copy-to-clipboard button for code blocks */
+pre.copy-wrap {
+  position: relative;
+}
+
+.copy-btn {
+  @extend %btn-base;
+  position: absolute;
+  top: .25em;
+  right: .25em;
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0.2em;
+}
+

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,0 +1,25 @@
+(() => {
+  function addButtons(scope = document) {
+    scope.querySelectorAll('pre > code').forEach(code => {
+      const pre = code.parentElement;
+      if (pre.querySelector('.copy-btn')) return;
+      pre.classList.add('copy-wrap');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'copy-btn';
+      btn.innerHTML =
+        '<span class="material-symbols-outlined btn-icon-material-symbols" aria-hidden="true">content_copy</span>';
+      btn.addEventListener('click', () => {
+        navigator.clipboard.writeText(code.innerText).catch(() => {});
+      });
+      pre.appendChild(btn);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => addButtons());
+  } else {
+    addButtons();
+  }
+  document.addEventListener('turbo:load', () => addButtons());
+})();


### PR DESCRIPTION
## Summary
- inject new `copy-code.js` script in default layout
- style copy button in critical and component CSS
- implement JS to attach a transparent copy button to every `pre > code`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6877e121cc208331bdfcefc294dee1ee