### PR TITLE
Fix CodeMirror imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This repository contains the source for a Jekyll-based personal website. Below i
 - `_includes/` – Reusable partial templates and assets. For example, `task-head-template.html` and `task-body-template.html` are injected into `algoprep/task.html` when rendering algorithm tasks.
 - `_layouts/` – Page layouts for Jekyll. `default.html` is the base layout and `post.html` extends it for blog posts. Markdown files in `_posts/` and pages like `about.md` use these layouts via their front-matter.
 - `_posts/` – Blog posts written in Markdown. Each file has YAML front-matter specifying `layout: post` so they render with `_layouts/post.html`.
-- `assets/` – Static assets. Contains SCSS stylesheets under `css/`, JavaScript modules in `js/`, GitHub logos in `github/`, and images under `python/`.
+- `assets/` – Static assets. Contains SCSS stylesheets under `css/`, JavaScript modules in `js/` (e.g., `editor.js` bundles CodeMirror imports), GitHub logos in `github/`, and images under `python/`.
 - `algoprep/` – JSON definitions of algorithm tasks and the `index.md` page for the Algoprep section. `scripts/prerender-tasks.mjs` reads these JSON files to generate static HTML using the templates from `_includes/`.
 - `blog/` – Landing page for the blog. Displays the latest post and links to others.
 - `logos-flavicon/` – Favicon and web manifest files.

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1,13 +1,13 @@
-import {EditorView, lineNumbers, keymap, drawSelection} from "https://esm.sh/@codemirror/view";
-import {python} from "https://esm.sh/@codemirror/lang-python";
+import {EditorView, lineNumbers, keymap, drawSelection} from "https://esm.sh/@codemirror/view?bundle";
+import {python} from "https://esm.sh/@codemirror/lang-python?bundle";
 
-import {githubDark, githubLight} from "https://esm.sh/@uiw/codemirror-theme-github";
-import {Compartment} from "https://esm.sh/@codemirror/state";
-import {lintKeymap} from "https://esm.sh/@codemirror/lint";
-import {searchKeymap, highlightSelectionMatches as selectionMatches} from "https://esm.sh/@codemirror/search";
+import {githubDark, githubLight} from "https://esm.sh/@uiw/codemirror-theme-github?bundle";
+import {Compartment} from "https://esm.sh/@codemirror/state?bundle";
+import {lintKeymap} from "https://esm.sh/@codemirror/lint?bundle";
+import {searchKeymap, highlightSelectionMatches as selectionMatches} from "https://esm.sh/@codemirror/search?bundle";
 
-import {insertTab, history} from "https://esm.sh/@codemirror/commands";
-import {autocompletion, closeBrackets} from "https://esm.sh/@codemirror/autocomplete";
+import {insertTab, history} from "https://esm.sh/@codemirror/commands?bundle";
+import {autocompletion, closeBrackets} from "https://esm.sh/@codemirror/autocomplete?bundle";
 
 const themeCompartment = new Compartment();
 


### PR DESCRIPTION
## Summary
- bundle CodeMirror imports so dependencies resolve on GitHub Pages
- document the change in `AGENTS.md`

## Testing
- `bundle exec jekyll build`
- `node scripts/prerender-tasks.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6877da635f788331b9468536fb119e49