### PR TITLE
Fix copy button for CodeMirror blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This repository contains the source for a Jekyll-based personal website. Below i
 - `_layouts/` – Page layouts for Jekyll. `default.html` is the base layout and `post.html` extends it for blog posts. Markdown files in `_posts/` and pages like `about.md` use these layouts via their front-matter.
 - `_posts/` – Blog posts written in Markdown. Each file has YAML front-matter specifying `layout: post` so they render with `_layouts/post.html`.
 - `assets/` – Static assets. Contains SCSS stylesheets under `css/`, JavaScript modules in `js/` (e.g., `editor.js` bundles CodeMirror modules from a CDN while sharing a single `@codemirror/state` instance), GitHub logos in `github/`, and images under `python/`.
+  Code blocks with classes like `language-python-codemirror` are replaced at runtime by `editor.js` with `<div class="cm-static-view" data-code="…">` wrappers. Features such as the copy button should target these elements.
 - `algoprep/` – JSON definitions of algorithm tasks, the `index.md` page, and the dynamic `task.html` used for interactive code execution. `scripts/prerender-tasks.mjs` reads these JSON files to generate static HTML using the templates from `_includes/`.
 - `blog/` – Landing page for the blog. Displays the latest post and links to others.
 - `logos-flavicon/` – Favicon and web manifest files.

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,7 +1,7 @@
 (() => {
   function addButtons(scope = document) {
-    scope.querySelectorAll('pre > code').forEach(code => {
-      const pre = code.parentElement;
+    scope.querySelectorAll('pre > code, .cm-static-view').forEach(el => {
+      const pre = el.matches('pre > code') ? el.parentElement : el;
       if (pre.querySelector('.copy-btn')) return;
       pre.classList.add('copy-wrap');
       const btn = document.createElement('button');
@@ -10,7 +10,10 @@
       btn.innerHTML =
         '<span class="material-symbols-outlined btn-icon-material-symbols" aria-hidden="true">content_copy</span>';
       btn.addEventListener('click', () => {
-        navigator.clipboard.writeText(code.innerText).catch(() => {});
+        const text = el.matches('pre > code')
+          ? el.innerText
+          : el.getAttribute('data-code') || '';
+        navigator.clipboard.writeText(text).catch(() => {});
       });
       pre.appendChild(btn);
     });


### PR DESCRIPTION
## Summary
- support `.cm-static-view` containers in the copy code script
- document CodeMirror block replacement in `AGENTS.md`

## Testing
- `node scripts/prerender-tasks.mjs` *(fails: ENOENT _site/algoprep/task/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_6878fc42b9fc83319a35be0889303596