### PR TITLE
Fix copy button with dynamic code rendering

### DIFF
--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,6 +1,5 @@
-(() => {
-  function addButtons(scope = document) {
-    scope.querySelectorAll('pre > code, .cm-static-view').forEach(el => {
+export function addCopyButtons(scope = document) {
+  scope.querySelectorAll('pre > code, .cm-static-view').forEach(el => {
       const pre = el.matches('pre > code') ? el.parentElement : el;
       if (pre.querySelector('.copy-btn')) return;
       pre.classList.add('copy-wrap');
@@ -17,12 +16,14 @@
       });
       pre.appendChild(btn);
     });
-  }
+  });
+}
 
+if (typeof document !== 'undefined') {
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => addButtons());
+    document.addEventListener('DOMContentLoaded', () => addCopyButtons());
   } else {
-    addButtons();
+    addCopyButtons();
   }
-  document.addEventListener('turbo:load', () => addButtons());
-})();
+  document.addEventListener('turbo:load', () => addCopyButtons());
+}

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -20,6 +20,7 @@ import {
 } from '/assets/js/test-fields.js';
 import { loadTaskState, saveTaskState } from '/assets/js/user-state.js';
 import { callFromSignature } from '/assets/js/task-render-core.js';
+import { addCopyButtons } from '/assets/js/copy-code.js';
 
 const themeCompartment = new Compartment();
 
@@ -137,6 +138,7 @@ export function renderReadOnlyCodeBlocks() {
       parent: wrapper
     });
   });
+  addCopyButtons();
 }
 
 
@@ -177,6 +179,7 @@ export function renderReadOnlyInputOutputBlocks() {
       parent: wrapper
     });
   });
+  addCopyButtons();
 }
 
 


### PR DESCRIPTION
## Summary
- expose `addCopyButtons` in `copy-code.js`
- invoke copy button setup after static code blocks are rendered

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68791304203483318689f13fdd2fe446