### PR TITLE
Implement open-user-state integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,11 @@ This repository contains the source for a Jekyll-based personal website. Below i
 ## Core Directories
 
 - `_data/` – YAML data files used by Jekyll. `nav.yml` defines the site navigation and is referenced by layout templates.
-- `_includes/` – Reusable partial templates and assets. For example, `task-head-template.html` and `task-body-template.html` are injected into `algoprep/task.html` when rendering algorithm tasks.
+ - `_includes/` – Reusable partial templates and assets. For example, `task-head-template.html` and `task-body-template.html` are injected into `algoprep/task.html` when rendering algorithm tasks. `user-state-modal.html` defines the modal for saving user progress.
 - `_layouts/` – Page layouts for Jekyll. `default.html` is the base layout and `post.html` extends it for blog posts. Markdown files in `_posts/` and pages like `about.md` use these layouts via their front-matter.
 - `_posts/` – Blog posts written in Markdown. Each file has YAML front-matter specifying `layout: post` so they render with `_layouts/post.html`.
-- `assets/` – Static assets. Contains SCSS stylesheets under `css/`, JavaScript modules in `js/` (e.g., `editor.js` bundles CodeMirror modules from a CDN while sharing a single `@codemirror/state` instance), GitHub logos in `github/`, and images under `python/`.
-  Code blocks with classes like `language-python-codemirror` are replaced at runtime by `editor.js` with `<div class="cm-static-view" data-code="…">` wrappers. Features such as the copy button should target these elements.
+ - `assets/` – Static assets. Contains SCSS stylesheets under `css/`, JavaScript modules in `js/` (e.g., `editor.js` bundles CodeMirror modules from a CDN while sharing a single `@codemirror/state` instance), GitHub logos in `github/`, and images under `python/`. The `state-settings.js` module drives the user state modal and `user-state.js` syncs progress via the Open User State backend deployed at `open-user-state-personal-website.viktoroo-sch.workers.dev`.
+   Code blocks with classes like `language-python-codemirror` are replaced at runtime by `editor.js` with `<div class="cm-static-view" data-code="…">` wrappers. Features such as the copy button should target these elements.
 - `algoprep/` – JSON definitions of algorithm tasks, the `index.md` page, and the dynamic `task.html` used for interactive code execution. `scripts/prerender-tasks.mjs` reads these JSON files to generate static HTML using the templates from `_includes/`.
 - `blog/` – Landing page for the blog. Displays the latest post and links to others.
 - `logos-flavicon/` – Favicon and web manifest files.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the source for my personal website. The site is built w
 
 **Algoprep** is an interactive collection of Python algorithm problems. Tasks can be solved right in the browser thanks to Pyodide. You can visit it at [`/algoprep/`](https://viktor-shcherb.github.io/algoprep/).
 
+Task progress can be saved remotely via [Open User State](https://github.com/viktor-shcherb/open-user-state). Use the settings cog next to the test results to authenticate with GitHub and choose a repository. The backend runs at [open-user-state-personal-website.viktoroo-sch.workers.dev](https://open-user-state-personal-website.viktoroo-sch.workers.dev/).
+
 #### Contributing a Task
 
 1. Go to the [Algoprep page](https://viktor-shcherb.github.io/algoprep/) and click **"Contribute new task"**.

--- a/_includes/user-state-modal.html
+++ b/_includes/user-state-modal.html
@@ -1,0 +1,33 @@
+<div id="user-state-modal" class="contribute-modal">
+  <div class="modal-overlay"></div>
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2>User State Settings</h2>
+      <button type="button" class="modal-close" title="Close">
+        <span class="material-symbols-outlined" aria-hidden="true">close</span>
+        <span class="visually-hidden">Close</span>
+      </button>
+    </div>
+    <div class="modal-body">
+      <p id="auth-warning">Authenticate to persist your progress remotely.</p>
+      <button type="button" id="github-auth-btn" class="add-btn">Authenticate via GitHub</button>
+      <div id="pat-section" style="display:none; margin-top:1em;">
+        <p class="hint">
+          Provide a fine-grained PAT restricted to the repository you wish to use. 
+          Your token will be stored with <a href="https://github.com/viktor-shcherb/open-user-state" target="_blank" rel="noopener">Open User State</a>.
+        </p>
+        <label style="display:block; margin-top:.5em;">
+          <span>Repository</span>
+          <input id="repo-input" placeholder="owner/repo">
+        </label>
+        <label style="display:block; margin-top:.5em;">
+          <span>GitHub PAT</span>
+          <input id="pat-input" type="password" autocomplete="off">
+        </label>
+        <button type="button" id="save-pat-btn" class="submit-btn" style="margin-top:1em;">
+          Save Settings
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/algoprep/task.html
+++ b/algoprep/task.html
@@ -51,7 +51,12 @@ uses_pyodide: true
     <section class="tab-panel code-panel" id="panel-code">
       <div id="editor"></div>
       <div class="code-runner">
-        <div id="runner-status" class="status-row"></div>
+        <div class="status-row">
+          <span id="runner-status"></span>
+          <button type="button" id="state-settings-btn" class="settings-btn" title="State settings">
+            <span class="material-symbols-outlined" aria-hidden="true">settings</span>
+          </button>
+        </div>
         <div class="controls-row">
           <label class="timeout-label">
             <span>timeout</span>
@@ -69,6 +74,8 @@ uses_pyodide: true
           <button id="stop-code-btn" class="stop-btn" type="button" title="Stop" disabled>
             <span class="material-symbols-outlined" aria-hidden="true">stop</span>
           </button>
+          <input id="save-name" class="save-name-input" placeholder="Save name" style="display:none;">
+          <span id="state-warning" class="state-warning">Progress may be erased without authentication</span>
         </div>
         <div class="checks-row">
           <label>
@@ -105,4 +112,5 @@ uses_pyodide: true
 
 <script type="module" src="/assets/js/task-page.js"></script>
 {% include contribute-modal.html %}
+{% include user-state-modal.html %}
 <script type="module" src="/assets/js/algoprep-contribute.js"></script>

--- a/assets/css/_components.scss
+++ b/assets/css/_components.scss
@@ -126,6 +126,9 @@ input#tab-preview:checked + label[for="tab-preview"],
 }
 
 .status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-size: 0.9rem;
   color: var(--text-muted);
 }
@@ -158,6 +161,30 @@ input#tab-preview:checked + label[for="tab-preview"],
 .stop-btn {
   @extend .run-btn;
   color: var(--red);
+}
+
+.settings-btn {
+  @extend %btn-base;
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.2em;
+  display: flex;
+  align-items: center;
+}
+
+.state-warning {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.save-name-input {
+  font-size: 0.8rem;
+  padding: 0.2em 0.4em;
+  border: 1px solid var(--accent-disabled);
+  border-radius: 4px;
 }
 
 .run-btn:disabled,
@@ -777,6 +804,8 @@ select{
   overflow:hidden;
   clip:rect(0 0 0 0); border:0;
 }
+
+.hidden { display:none !important; }
 
 .auto-grow{
   /* keep the browser from adding scrollbars while we grow */

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -44,6 +44,8 @@ function persistExtension(slug, state) {
   return EditorView.updateListener.of(update => {
     if (update.docChanged) {
       state.code = update.state.doc.toString();
+      const input = document.getElementById('save-name');
+      if (input) state.name = input.value.trim();
       saveTaskState(slug, state);
     }
   });
@@ -80,7 +82,7 @@ export async function setupEditor(initialDoc, slug = null) {
   const isVisible = !!(editorContainer.offsetWidth || editorContainer.offsetHeight || editorContainer.getClientRects().length);
   if (!isVisible) return;
 
-  const state = slug ? loadTaskState(slug) : {};
+  const state = slug ? await loadTaskState(slug) : {};
   let savedDoc = state.code;
   if (!savedDoc) {
     savedDoc = typeof initialDoc === "string" ? initialDoc : "# Write your Python code here\nprint('Hello!')";
@@ -183,7 +185,9 @@ export function renderReadOnlyInputOutputBlocks() {
 let pyodideReadyPromise = null;
 
 export async function setupRunner(task) {
-  const state = loadTaskState(task.slug);
+  const state = await loadTaskState(task.slug);
+  const saveInput = document.getElementById('save-name');
+  if (saveInput && state.name) saveInput.value = state.name;
   const runBtn = document.getElementById('run-code-btn');
   const testsList = document.getElementById('tests-list');
   const addTestBtn = document.getElementById('add-test');
@@ -300,6 +304,8 @@ export async function setupRunner(task) {
     state.tests = [...testsList.querySelectorAll('.test-item')]
       .filter(el => !el.classList.contains('sample-test'))
       .map(serializeTest);
+    const input = document.getElementById('save-name');
+    if (input) state.name = input.value.trim();
     saveTaskState(task.slug, state);
   }
 

--- a/assets/js/state-settings.js
+++ b/assets/js/state-settings.js
@@ -1,0 +1,85 @@
+const API_BASE = 'https://open-user-state-personal-website.viktoroo-sch.workers.dev';
+
+export async function initStateSettings() {
+  const btn = document.getElementById('state-settings-btn');
+  const modal = document.getElementById('user-state-modal');
+  const warning = document.getElementById('state-warning');
+  const saveInput = document.getElementById('save-name');
+  if (!btn || !modal) return;
+
+  function toggleAuth(auth) {
+    if (auth) {
+      warning?.classList.add('hidden');
+      if (saveInput) saveInput.style.display = 'inline-block';
+    } else {
+      warning?.classList.remove('hidden');
+      if (saveInput) saveInput.style.display = 'none';
+    }
+  }
+
+  btn.addEventListener('click', () => modal.classList.add('open'));
+  modal.addEventListener('click', e => {
+    if (e.target.closest('.modal-close') || e.target.classList.contains('modal-overlay'))
+      modal.classList.remove('open');
+  });
+  document.addEventListener('keyup', e => {
+    if (e.key === 'Escape') modal.classList.remove('open');
+  });
+
+  const authBtn = document.getElementById('github-auth-btn');
+  const patSection = document.getElementById('pat-section');
+  const savePatBtn = document.getElementById('save-pat-btn');
+  const repoInput = document.getElementById('repo-input');
+  const patInput = document.getElementById('pat-input');
+
+  async function checkAuth() {
+    try {
+      const res = await fetch(`${API_BASE}/api/repository`, { credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.repo && repoInput) repoInput.value = data.repo;
+        authBtn.style.display = 'none';
+        patSection.style.display = 'block';
+        toggleAuth(true);
+      } else {
+        authBtn.style.display = 'block';
+        patSection.style.display = 'none';
+        toggleAuth(false);
+      }
+    } catch {
+      authBtn.style.display = 'block';
+      patSection.style.display = 'none';
+      toggleAuth(false);
+    }
+  }
+
+  authBtn?.addEventListener('click', async () => {
+    const res = await fetch(`${API_BASE}/api/auth/github`, { method: 'POST', credentials: 'include' });
+    if (res.redirected) window.location.href = res.url;
+  });
+
+  savePatBtn?.addEventListener('click', async () => {
+    const pat = patInput.value.trim();
+    const repo = repoInput.value.trim();
+    if (pat) {
+      await fetch(`${API_BASE}/api/token`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pat })
+      });
+    }
+    if (repo) {
+      await fetch(`${API_BASE}/api/repository`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repo })
+      });
+    }
+    modal.classList.remove('open');
+    toggleAuth(true);
+  });
+
+  await checkAuth();
+}

--- a/assets/js/task-page.js
+++ b/assets/js/task-page.js
@@ -9,6 +9,7 @@ import { renderTask,
 import { setupEditor,
          setupRunner,
          updateEditorTheme } from '/assets/js/editor.js';
+import { initStateSettings } from '/assets/js/state-settings.js';
 
 let currentTask, editorReady = false;
 
@@ -36,6 +37,7 @@ async function renderPage() {
   //    content is in place.
   initTabSwitcher(document);
   updateEditorTheme();
+  initStateSettings();
 }
 
 // first run + every Turbo visit
@@ -46,7 +48,7 @@ document.addEventListener('themechange', updateEditorTheme);
 
 document.addEventListener('tabshown', async ({ detail }) => {
   if (detail.panel.id !== 'panel-code' || editorReady) return;
-  setupEditor(signatureToDef(currentTask.signature), currentTask.slug);
-  setupRunner(currentTask);
+  await setupEditor(signatureToDef(currentTask.signature), currentTask.slug);
+  await setupRunner(currentTask);
   editorReady = true;
 });

--- a/assets/js/user-state.js
+++ b/assets/js/user-state.js
@@ -1,12 +1,56 @@
-export function loadTaskState(slug) {
+const API_BASE = 'https://open-user-state-personal-website.viktoroo-sch.workers.dev';
+
+async function fetchFile(path) {
   try {
-    const json = localStorage.getItem(`task-state:${slug}`);
-    return json ? JSON.parse(json) : {};
-  } catch {
-    return {};
-  }
+    const res = await fetch(`${API_BASE}/api/file?path=${encodeURIComponent(path)}`, { credentials: 'include' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.content;
+  } catch { return null; }
 }
 
-export function saveTaskState(slug, state) {
+async function commitFile(path, content, message) {
+  try {
+    await fetch(`${API_BASE}/api/file`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path, content, message })
+    });
+  } catch {}
+}
+
+export async function loadTaskState(slug) {
+  try {
+    const json = localStorage.getItem(`task-state:${slug}`);
+    if (json) return JSON.parse(json);
+  } catch {}
+
+  const meta = await fetchFile(`user_state/algoprep/${slug}/metadata.json`);
+  if (!meta) return {};
+  const state = {};
+  try {
+    Object.assign(state, JSON.parse(meta));
+  } catch {}
+  state.code = await fetchFile(`user_state/algoprep/${slug}/code.py`) || '';
+  const tests = await fetchFile(`user_state/algoprep/${slug}/custom_tests.json`);
+  if (tests) {
+    try { state.tests = JSON.parse(tests); } catch {}
+  }
   localStorage.setItem(`task-state:${slug}`, JSON.stringify(state));
+  return state;
+}
+
+export async function saveTaskState(slug, state) {
+  state.lastSaved = Date.now();
+  localStorage.setItem(`task-state:${slug}`, JSON.stringify(state));
+  await commitFile(
+    `user_state/algoprep/${slug}/metadata.json`,
+    JSON.stringify({ lastSaved: state.lastSaved, name: state.name || '' }),
+    `Update state meta for ${slug}`
+  );
+  if ('code' in state) {
+    await commitFile(`user_state/algoprep/${slug}/code.py`, state.code, `Update code for ${slug}`);
+  }
+  await commitFile(`user_state/algoprep/${slug}/custom_tests.json`, JSON.stringify(state.tests || []), `Update tests for ${slug}`);
 }


### PR DESCRIPTION
## Summary
- add user state modal for GitHub authentication
- persist task state to the Open User State backend
- expose a settings button and save name input on task pages
- style the new controls in SCSS
- document new files in AGENTS.md
- adjust API calls to use the deployed backend

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6879117081208331ae9b2b6c6e5b1974