### PR TITLE
Add tab anchors and auth redirect to interpreter

### DIFF
--- a/algoprep/task.html
+++ b/algoprep/task.html
@@ -11,7 +11,7 @@ uses_pyodide: true
   <div class="tab-btn-row" role="tablist">
     <!-- — Task description — -->
     <input  type="radio" id="tab-desc" name="tasktab"
-            data-panel=".task-preview" checked hidden>
+            data-panel=".task-preview" data-anchor="desc" checked hidden>
     <label  for="tab-desc" class="tab-btn" role="tab" aria-controls="panel-desc">
       <span class="material-symbols-outlined btn-icon-material-symbols"
             aria-hidden="true">description</span>
@@ -20,7 +20,7 @@ uses_pyodide: true
 
     <!-- — Code interpreter — -->
     <input  type="radio" id="tab-code" name="tasktab"
-            data-panel="#panel-code" hidden>
+            data-panel="#panel-code" data-anchor="code" hidden>
     <label  for="tab-code" class="tab-btn" role="tab" aria-controls="panel-code">
       <img src="/assets/python/logo-white.png" alt="Python" class="btn-icon">
       Code Interpreter

--- a/assets/js/state-settings.js
+++ b/assets/js/state-settings.js
@@ -131,7 +131,7 @@ export async function initStateSettings() {
         const next =
           window.location.pathname +
           window.location.search +
-          window.location.hash;
+          '#code';
         window.location.href = `${API_BASE}/api/auth/github?next=${encodeURIComponent(next)}`;
         return;
       }

--- a/assets/js/tab-switcher.js
+++ b/assets/js/tab-switcher.js
@@ -1,10 +1,18 @@
 export function initTabSwitcher(root = document) {
   // find every .tab-switcher in `root`
   root.querySelectorAll('.tab-switcher').forEach(switcher => {
-    const radios = switcher.querySelectorAll('input[type="radio"][data-panel]');
+    const radios = Array.from(
+      switcher.querySelectorAll('input[type="radio"][data-panel]')
+    );
     const labels = switcher.querySelectorAll('label');
 
-    function show(panelSel){
+    const anchorMap = new Map();
+    radios.forEach(r => {
+      if (r.dataset.anchor) anchorMap.set(r.dataset.anchor, r);
+    });
+    const useHash = anchorMap.size > 0;
+
+    function show(panelSel, anchor){
       // hide all panels in this switcher
       radios.forEach(r => {
         const panel = document.querySelector(r.dataset.panel);
@@ -19,17 +27,39 @@ export function initTabSwitcher(root = document) {
       switcher.dispatchEvent(new CustomEvent('tabshown', {
         detail:{panel: document.querySelector(panelSel)}, bubbles:true
       }));
+
+      if (useHash && anchor) {
+        history.replaceState(null, '', '#' + anchor);
+      }
+    }
+
+    function applyHash(hash){
+      if (!useHash || !hash) return;
+      const anchor = hash.replace(/^#/, '');
+      const radio = anchorMap.get(anchor);
+      if (radio) {
+        radio.checked = true;
+        show(radio.dataset.panel, anchor);
+      }
     }
 
     // initial state
     const current = switcher.querySelector('input[type="radio"]:checked');
-    if (current) show(current.dataset.panel);
+    if (useHash && location.hash) {
+      applyHash(location.hash);
+    } else if (current) {
+      show(current.dataset.panel, current.dataset.anchor);
+    }
 
     // delegate change events
     switcher.addEventListener('change', e => {
       if (e.target.matches('input[type="radio"][data-panel]')) {
-        show(e.target.dataset.panel);
+        show(e.target.dataset.panel, e.target.dataset.anchor);
       }
     });
+
+    if (useHash) {
+      window.addEventListener('hashchange', () => applyHash(location.hash));
+    }
   });
 }


### PR DESCRIPTION
## Summary
- make task tabs navigable via URL anchors
- default auth redirects back to the interpreter tab

## Testing
- `npm install`
- `node -c assets/js/tab-switcher.js`
- `node -c assets/js/state-settings.js`


------
https://chatgpt.com/codex/tasks/task_e_687ba7ef928c83318415826dfd7d5c01