### PR TITLE
Replace service worker with self-unregistering stub

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,12 +1,14 @@
 /* ------------------------------------------------------------------
- *  – registers the Service Worker
+ *  – registers the (self-unregistering) Service Worker
  *  – handles the nav dropdowns with event-delegation
- *  – repeats the loader-fade after every Turbo navigation
  * ----------------------------------------------------------------- */
 
 /* ———————————————————————————————————————— service-worker — */
+/* The SW only exists to clean up a previous install from the algoprep
+ * era. Once activated, it unregisters itself; visitors with no prior
+ * SW will register the stub and immediately drop it. Both calls are
+ * deferred to load so they never block first paint. */
 if ('serviceWorker' in navigator) {
-  /* defer until full load so it never blocks first paint */
   window.addEventListener('load', () =>
     navigator.serviceWorker.register('/service-worker.js').catch(() => {})
   );

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,47 +1,20 @@
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+/*
+ * Self-unregistering stub. The previous service worker cached the algoprep
+ * Pyodide and task JSON; both are gone. Visitors who installed the old SW
+ * still have it registered, so this stub clears its caches, unregisters
+ * itself, and reloads any open pages so they fetch the live site.
+ *
+ * Once telemetry / time confirms no clients hit this anymore, the file and
+ * its registration in main.js can be removed entirely.
+ */
+self.addEventListener('install', () => self.skipWaiting());
 
-const CACHE = 'tasks-v1';
-const TTL = 3600_000;               // 1h
-
-self.__WB_DISABLE_DEV_LOGS = true;
-self.skipWaiting();
-workbox.core.clientsClaim();
-
-workbox.precaching.precacheAndRoute([
-  {url: 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js', revision: null}
-]);
-
-workbox.routing.registerRoute(
-  ({url}) => url.origin === 'https://cdn.jsdelivr.net' && url.pathname.startsWith('/pyodide/'),
-  new workbox.strategies.StaleWhileRevalidate({cacheName: 'pyodide-cache'})
-);
-
-self.addEventListener('fetch', event => {
-  const {request} = event;
-  if (!request.url.includes('/algoprep/') || !request.url.endsWith('.json')) return;
-
-  event.respondWith((async () => {
-    const cache = await caches.open(CACHE);
-    const cached = await cache.match(request);
-
-    // Serve cached copy if < 1 h old
-    if (cached) {
-      const ts = +cached.headers.get('sw-fetched-at');
-      if (Date.now() - ts < TTL) return cached;
-    }
-
-    // Otherwise go to network and refresh cache
-    const res  = await fetch(request, {cache: 'no-store'});
-    if (res.ok) {
-      const headers = new Headers(res.headers);
-      headers.set('sw-fetched-at', Date.now());
-      const copy = new Response(await res.clone().blob(), {
-        status:     res.status,
-        statusText: res.statusText,
-        headers
-      });
-      cache.put(request, copy);
-    }
-    return res;
+self.addEventListener('activate', event => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.map(k => caches.delete(k)));
+    await self.registration.unregister();
+    const clients = await self.clients.matchAll();
+    clients.forEach(c => c.navigate(c.url));
   })());
 });


### PR DESCRIPTION
Closes #45.

## Summary
- Replace `service-worker.js` with a stub that clears caches, calls `registration.unregister()`, and reloads matched clients so they refresh against the live site.
- Update the comment block in `assets/js/main.js` and keep the SW registration call so existing visitors install the stub once and drop it.

## Follow-up
After enough time (≥6 months) confirms no clients still on the old SW, delete `service-worker.js` and the `navigator.serviceWorker.register` call entirely.

## Test plan
- [ ] On a deployed preview, open the site in a browser that previously had the old SW (or simulate via DevTools "Update on reload"). Confirm the SW reports as unregistered after one reload and no caches remain.