### PR TITLE
Drop Turbo Drive

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,10 +36,6 @@
     <noscript><link rel="stylesheet"
           href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"></noscript>
 
-    <!-- Turbo Drive -->
-    <script type="module"
-            src="https://unpkg.com/@hotwired/turbo@8/dist/turbo.es2017-esm.js" crossorigin="anonymous"></script>
-
     <!-- speculation rules -->
     <script type="speculationrules">
     { "prerender": [ { "source":"list","urls":["/blog/","/about/","/"] } ] }
@@ -82,7 +78,7 @@
           {% endfor %}
 
           <button id="theme-toggle" class="theme-btn"
-            aria-label="Toggle colour scheme" data-turbo-permanent>
+            aria-label="Toggle colour scheme">
             <span class="material-symbols-outlined" id="theme-icon" aria-hidden="true" data-icon></span>
           </button>
         </nav>

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -1,7 +1,6 @@
 /* ------------------------------------------------------------------
  *  • lazy-loads Anchor-JS the first time it’s needed
  *  • adds clean, right-hand anchor links to every heading
- *  • re-runs on each Turbo navigation so “next/prev” posts work
  * ----------------------------------------------------------------- */
 
 (() => {
@@ -37,11 +36,10 @@
     });
   }
 
-  /* ---------------------------------------------------- run once + on Turbo */
+  /* ---------------------------------------------------- run once */
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', addHeadingAnchors, { once: true });
   } else {
     addHeadingAnchors();
   }
-  document.addEventListener('turbo:load', addHeadingAnchors);
 })();

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -39,9 +39,3 @@ function applyTheme(isDark){
 
 /* --- once fonts are ready, paint all glyphs --------------------- */
 document.fonts.ready.then(paintMaterialIcons.bind(null, document));
-
-/* --- repaint on every Turbo render (new <body>) ----------------- */
-document.addEventListener('turbo:render', () => {
-  setIcon(root.dataset.theme === 'dark');   // refresh the toggle itself
-  paintMaterialIcons();                     // paint any new glyphs
-});


### PR DESCRIPTION
Closes #46.

## Summary
- Remove the Turbo `<script type="module">` from `_layouts/default.html`. Speculation rules stay; they prerender Home/Blog/About without JS.
- Drop the `data-turbo-permanent` attribute on the theme toggle.
- Drop `turbo:render` listener in `theme-toggle.js` (theme is set pre-paint via `theme-sniff`, persists on real navigations).
- Drop `turbo:load` listener in `post.js` (`DOMContentLoaded` is enough on a real navigation).

## Test plan
- [ ] Click through Home → Blog → About → an individual post on a deployed preview. Confirm theme persists across navigations and post heading anchors render.
- [x] `grep -rn turbo` is clean.