### PR TITLE
Drop pages-themes/minimal remote theme and consolidate CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Viktor Shcherbakov
 tagline: Machine Learning Engineer
 description: >-
-  This is a personal website where I write about my experience, thoughts and share 
+  This is a personal website where I write about my experience, thoughts and share
   potentially useful information.
 url: "https://viktor-shcherb.github.io"
 baseurl: ""
@@ -16,9 +16,7 @@ future: true          # tells Jekyll to publish posts dated in the future
 # remove .html from the blog pages
 permalink: /:year/:month/:day/:title/
 
-remote_theme: pages-themes/minimal
 plugins:
-  - jekyll-remote-theme
   - jekyll-seo-tag
   - jekyll-sitemap
   - jekyll-feed
@@ -27,11 +25,6 @@ plugins:
 sass:
   load_paths:
     - assets/css
-defaults:
-  -
-    scope: { path: "" }
-    values:
-      header: header-custom
 
 feed:
   path: feed.xml
@@ -41,4 +34,3 @@ feed:
   author_name: Viktor Shcherbakov
   author_url: https://viktor-shcherb.github.io/about/
   full_content: true
-

--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -1,89 +1,51 @@
 /* --- Critical CSS for initial render --- */
-:root{
-  --bg:          #ffffff;  /* light mode */
-  --surface:     #efefef;
-  --text:        #232730;
+:root {
+  --bg:      #ffffff;
+  --surface: #efefef;
+  --text:    #232730;
 
   --accent-h: 184deg;
   --accent-s: 50%;
-  --accent-l: 35%;      /* darker ⇒ passes contrast on light bg */
+  --accent-l: 35%;     /* darker → passes contrast on light bg */
   --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
 
-  /* tuned colours for tests */
-  --green: color-mix(in srgb, hsl(140deg 60% 40%) 80%, var(--accent));
-  --red:   color-mix(in srgb, hsl(0deg 70% 45%) 80%, var(--accent));
-  --surface-pass: color-mix(in srgb, var(--green) 15%, transparent);
-  --surface-fail: color-mix(in srgb, var(--red) 15%, transparent);
-
-  /*--accent:      #4b6f71; */
-  --surface-accented: color-mix(in srgb, var(--accent) 6%, transparent);
-
-  --text-muted:  #6f747d;  /* 60 % greyed version of --text */
-  --btn-disabled-bg: #6e747d;      /* same as text-muted */
-  --btn-text:        #ffffff;      /* one text colour for ALL buttons */
-
-  /* --- Overlay / glass --- */
-  --glass-overlay-clr : rgba(20 20 30 / .15);  /* tint colour   */
-  --glass-blur        : 6px;                  /* blur strength */
-  --glass-dim         : 1;                    /* brightness()  */
-
-  --surface-hover : color-mix(in srgb, var(--surface) 90%, black 10%);
-  --surface-active: color-mix(in srgb, var(--surface) 80%, black 20%);
-
-  --accent-disabled: #b3b7c0;
+  --text-muted: #6f747d;
 }
 
-[data-theme='dark']{
-  --bg:          #232730;
-  --surface:     #31353e;
-  --text:        #efefef;
+[data-theme='dark'] {
+  --bg:      #232730;
+  --surface: #31353e;
+  --text:    #efefef;
+
   --accent-s: 15%;
-  --accent-l: 50%;      /* lighter ⇒ pops on dark bg */
-  /*--accent:      #82a9ac;*/
+  --accent-l: 50%;     /* lighter → pops on dark bg */
 
-  --green: color-mix(in srgb, hsl(140deg 60% 50%) 80%, var(--accent));
-  --red:   color-mix(in srgb, hsl(0deg 70% 60%) 80%, var(--accent));
-
-  --btn-disabled-bg: #31353e;      /* same as surface */
-  --text-muted:  #a9adb8;  /* 65 % tint of --text */
-
-  /* lighter tint + dimmer backdrop */
-  --glass-overlay-clr : rgba(255 255 255 / .08);
-  --glass-dim         : .7;
-
-  --surface-hover : color-mix(in srgb, var(--surface) 85%, white 15%);
-  --surface-active: color-mix(in srgb, var(--surface) 70%, white 30%);
-
-  --accent-disabled: #50545e;
+  --text-muted: #a9adb8;
 }
 
-html{
-  scrollbar-gutter: stable both-edges;
-}
-html{scrollbar-gutter:stable both-edges;}
-body{background:var(--bg);color:var(--text);font-family:sans-serif;margin:0;}
-.wrapper{max-width:80rem;margin:0 auto;}
-.site-nav{display:flex;align-items:center;gap:1rem;font-weight:600;}
-.site-nav a{position:relative;color:var(--accent);text-decoration:none;padding-block:.25rem;}
-.site-nav a::after{content:"";position:absolute;inset-inline:0;bottom:0;height:2px;border-radius:1px;background:transparent;transition:background .15s ease-in-out;}
-.site-nav a:hover::after,.site-nav a:focus-visible::after,.site-nav a.active::after{background:var(--accent);}
-.theme-btn{margin-left:auto;background:none;border:none;cursor:pointer;color:var(--accent);line-height:1;}
+html { scrollbar-gutter: stable both-edges; }
+body { background: var(--bg); color: var(--text); font-family: sans-serif; margin: 0; }
 
-.wrapper { position: relative; }
+.wrapper { max-width: 80rem; margin: 0 auto; position: relative; }
 
+/* Nav baseline (full styles in _base.scss) */
+.site-nav { display: flex; align-items: center; gap: 1rem; font-weight: 600; }
+.site-nav a { position: relative; color: var(--accent); text-decoration: none; padding-block: .25rem; }
+.site-nav a::after { content: ""; position: absolute; inset-inline: 0; bottom: 0; height: 2px; border-radius: 1px; background: transparent; transition: background .15s ease-in-out; }
+.site-nav a:hover::after, .site-nav a:focus-visible::after, .site-nav a.active::after { background: var(--accent); }
+.theme-btn { margin-left: auto; background: none; border: none; cursor: pointer; color: var(--accent); line-height: 1; }
+
+/* Code blocks (FOUC-safe baseline) */
 pre, code, .highlight {
-  background: var(--surface) !important;
-  color: var(--text) !important;
+  background: var(--surface);
+  color: var(--text);
   border-radius: 4px;
   padding: 0.4em 0.7em;
   font-family: 'Fira Mono', 'Consolas', monospace;
   font-size: 1em;
-  box-shadow: none;
-  border: none;
-  margin-top: 0rem;
+  margin-top: 0;
   margin-bottom: 1rem;
 }
-
 
 code {
   padding: 0.15em 0.35em;
@@ -91,35 +53,26 @@ code {
   font-size: 1em;
 }
 
-/* --- Icon image helper ------------------------------------- */
-/* Add class="btn-icon" (or .btn__icon) to any <img> inside a button. */
-.btn-icon{
-  height:1.4em;
-  width:1.4em;
-  font-size:1.4em;  /* for some reason this makes the size better */
-
-  /* — Layout — */
-  flex-shrink:0;        /* prevents icon from shrinking in flex buttons */
-  display:inline-block; /* ensures the width/height actually apply      */
-  vertical-align:middle;
+/* Icon helpers used by the copy-code button on first paint */
+.btn-icon {
+  height: 1.4em;
+  width: 1.4em;
+  font-size: 1.4em;
+  flex-shrink: 0;
+  display: inline-block;
+  vertical-align: middle;
   margin-right: .5em;
-
-  /* — Render quality + clean look — */
-  object-fit:contain;   /* avoid distortion for non-SVG images */
-  box-shadow:none !important;   /* nuke any inherited shadows */
-  filter:none !important;       /* avoid unexpected drop-shadows */
+  object-fit: contain;
 }
 
-.btn-icon-material-symbols{
-  font-size:1.65em !important;  /* material-symbols icons obey font-size, so set that too */
-
-  /* — Layout — */
-  flex-shrink:0;        /* prevents icon from shrinking in flex buttons */
-  display:inline-block; /* ensures the width/height actually apply      */
-  vertical-align:middle;
+.btn-icon-material-symbols {
+  font-size: 1.65em;
+  flex-shrink: 0;
+  display: inline-block;
+  vertical-align: middle;
   margin-right: .5em;
 }
 
-pre.copy-wrap{position:relative;}
-.copy-btn{position:absolute;top:.25em;right:.25em;background:none;border:none;color:var(--accent);cursor:pointer;padding:.2em;line-height:1;display:flex;align-items:center;}
-.copy-btn[data-copied]{color:var(--accent);}
+pre.copy-wrap { position: relative; }
+.copy-btn { position: absolute; top: .25em; right: .25em; background: none; border: none; color: var(--accent); cursor: pointer; padding: .2em; line-height: 1; display: flex; align-items: center; }
+.copy-btn[data-copied] { color: var(--accent); }

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -1,59 +1,20 @@
 /* --- Base layout and typography --- */
 
-/* Chrome */
-input[type="number"]::-webkit-outer-spin-button,
-input[type="number"]::-webkit-inner-spin-button{
-  -webkit-appearance:none;
-  margin:0;
-}
-/* Firefox */
-input[type="number"]{
-  -moz-appearance:textfield;
-}
+a, a:visited { color: var(--accent); }
+a:hover, a:focus { opacity: .75; }
 
-/* 2 — glue those vars onto Slate */
+hr { border-color: rgba(var(--text), .2); }
 
-/* body & headings */
-body{background:var(--bg)!important;color:var(--text)!important;}
-h1,h2,h3,h4,h5,h6{color:var(--text)!important;}
-
-/* links & buttons */
-a,a:visited{color:var(--accent);}
-a:hover,a:focus{opacity:.75;}
-
-/* code blocks / pre tags */
-pre,code{background:var(--surface);border:none;}
-
-/* cards / footer strip */
-.site-footer, .site-header{background:var(--surface);}
-
-/* optional — subtle border colour */
-hr{border-color:rgba(var(--text),.2);}
-
-/* 3 — tiny accessibility helper */
-@media (prefers-reduced-motion:reduce){
-  *{transition:none!important;}
-}
-
-.anchor-end{ display:none; }
-
-/* --- Strip header backdrop --- */
-
-header,                     /* fallback for plain <header>        */
-.site-header {              /* class if you added it earlier      */
-  background: none !important;   /* kill the grey rectangle      */
-  border: none;                  /* remove any bottom line       */
-  padding-block: 0;              /* optional: tighten vertical   */
-  box-shadow: none;              /* just in case theme adds one  */
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
 }
 
 /* --- Navigation --- */
 
-/* 1 ▸ container layout */
 .site-nav {
   display: flex;
   align-items: center;
-  gap: 1rem;              /* consistent breathing room            */
+  gap: 1rem;
   position: relative;
 }
 
@@ -63,12 +24,11 @@ header,                     /* fallback for plain <header>        */
   color: var(--accent);
   background: none;
   border: none;
-  padding-block: .25rem; /* match .site-nav a */
+  padding-block: .25rem;
   transition: color .15s;
   position: relative;
   cursor: pointer;
   text-decoration: none;
-  /* Ensure vertical alignment matches links */
   display: inline-block;
 }
 
@@ -77,22 +37,11 @@ header,                     /* fallback for plain <header>        */
   outline-offset: 2px;
 }
 
-/* some menu items have drop-down options */
-
-.dropdown-toggle {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 0rem;
-  font-family: inherit;
-}
-
 .dropdown-menu {
   display: none;
   position: absolute;
   background: var(--surface);
-  box-shadow: 0 4px 6px rgba(0,0,0,.1);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, .1);
   border-radius: 4px;
   padding: .5rem 0;
   min-width: 200px;
@@ -107,29 +56,24 @@ header,                     /* fallback for plain <header>        */
   transition: color .15s ease-in-out;
 }
 
-.dropdown:hover .dropdown-menu {
-  display: block;
-}
-
+.dropdown:hover .dropdown-menu,
 .dropdown.open .dropdown-menu {
   display: block;
 }
 
-/* 2 ▸ base link */
 .site-nav a {
-  position: relative;     /* enables the ::after underline        */
-  color: var(--accent);   /* default link tint                    */
+  position: relative;
+  color: var(--accent);
   text-decoration: none;
-  padding-block: .25rem;  /* reserves space for underline → no jump */
+  padding-block: .25rem;
   transition: color .15s ease-in-out;
 }
 
-/* 3 ▸ invisible underline that already occupies height            */
-/*     becomes visible on hover / focus / current page             */
+/* invisible underline that already occupies height; visible on hover/focus/current */
 .site-nav a::after {
   content: "";
   position: absolute;
-  inset-inline: 0;        /* left:0 & right:0 in logical terms    */
+  inset-inline: 0;
   bottom: 0;
   height: 2px;
   border-radius: 1px;
@@ -137,7 +81,6 @@ header,                     /* fallback for plain <header>        */
   transition: background .15s ease-in-out;
 }
 
-/* 4 ▸ interaction states                                           */
 .site-nav a:hover::after,
 .site-nav a:focus-visible::after,
 .site-nav a.active::after {
@@ -145,88 +88,70 @@ header,                     /* fallback for plain <header>        */
 }
 
 .site-nav a.active {
-  color: var(--text);     /* slightly darker when on the page     */
+  color: var(--text);
 }
 
-/* 5 ▸ accessible keyboard outline                                  */
 .site-nav a:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
 /* --- Footer --- */
-.site-footer{
-  display:flex;
-  justify-content:center;
-  padding:2rem 0 3rem;   /* extra bottom room for mobile gestures */
-  background:none;       /* match page background */
-  border-top:1px solid rgba(var(--text),.2);
+.site-footer {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0 3rem;
+  border-top: 1px solid rgba(var(--text), .2);
 }
 
-.theme-btn{
+/* --- Theme toggle --- */
+.theme-btn {
   margin-left: auto;
-  background:none;
-  border:none;
-  cursor:pointer;
-  font-size:.01rem;        /* icon size */
-  color:var(--accent);
-  line-height:1;
-  transition:background 0.2s;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: .01rem;
+  color: var(--accent);
+  line-height: 1;
+  transition: background 0.2s;
 }
 
-#theme-icon{
-  font-size:1.25rem;
-  width:1em;
-  display:inline-block;
+#theme-icon {
+  font-size: 1.25rem;
+  width: 1em;
+  display: inline-block;
 }
 
-.theme-btn:hover{
-  opacity: 0.75;
+.theme-btn:hover { opacity: 0.75; }
+
+/* --- Misc --- */
+.go-blog {
+  margin: 1rem 0 2rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
-.go-blog{
-  margin:1rem 0 2rem;
-  font-weight:600;
-  display:flex;
-  align-items:center;
-  gap:0.25rem;
+.go-blog a {
+  color: var(--accent);
+  text-decoration: none;
 }
 
-.go-blog a{
-  color:var(--accent);
-  text-decoration:none;
-}
+.go-blog a:hover { text-decoration: underline; }
+.go-blog .material-symbols-outlined { font-size: 1.2em; }
 
-.go-blog a:hover{ text-decoration:underline; }
-.go-blog .material-symbols-outlined{ font-size:1.2em; }
-
-.material-symbols-outlined{
-  display:inline-block;
-  width:1em;
-}
-
-
-a:hover,
-a:link,
-a:visited {
-  font-weight: normal;
-}
-
-strong,
-b{
-  color: var(--text);
-}
-
-table th {
-  color: var(--text);
+.material-symbols-outlined {
+  display: inline-block;
+  width: 1em;
 }
 
 .anchorjs-link::after {
   font-family: "Material Symbols Outlined";
-  content: "link";           /* the Material glyph name */
+  content: "link";
   font-size: 1em;
-  vertical-align: -0.15em;   /* lowers the icon a touch to align with text */
-  opacity: 0;                /* hidden until hover (matches visible:"hover") */
+  vertical-align: -0.15em;
+  opacity: 0;
   transition: opacity .15s ease;
   margin-left: .25rem;
 }
@@ -237,25 +162,23 @@ h3:hover .anchorjs-link::after,
 h4:hover .anchorjs-link::after,
 h5:hover .anchorjs-link::after,
 h6:hover .anchorjs-link::after {
-  opacity: .6;               /* fade in when the heading is hovered */
+  opacity: .6;
 }
 
 .img-caption {
   display: block;
-  margin-top: 0.0rem;
   font-size: 0.75rem;
-  color: var(--text-muted); // last value is the alpha channel
+  color: var(--text-muted);
   text-align: center;
   font-style: italic;
 }
 
 .post-content img {
-  display: block;            /* keeps the image on its own line */
-  border-radius: 8px;        /* soften the corners */
+  display: block;
+  border-radius: 8px;
   box-shadow:
-    0 2px 6px rgba(0,0,0,.2),   /* soft outer shadow */
-    0 1px 3px rgba(0,0,0,.1);   /* subtle inner lift */
-  max-width: 100%;           /* stay responsive */
-  height: auto;              /* keep aspect ratio when dims set */
+    0 2px 6px rgba(0, 0, 0, .2),
+    0 1px 3px rgba(0, 0, 0, .1);
+  max-width: 100%;
+  height: auto;
 }
-

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,6 +2,5 @@
 ---
 
 /* --- Main stylesheet imports --- */
-@import "{{ site.theme }}";
 @import "base";
 @import "components";


### PR DESCRIPTION
Closes #47.

## Summary
- Remove `remote_theme: pages-themes/minimal` and `jekyll-remote-theme` plugin from `_config.yml`. Drop the `defaults: header: header-custom` block (only the minimal theme used it).
- Drop `@import "{{ site.theme }}"` from `style.scss`.
- Strip `_base.scss` of every rule that existed solely to fight the minimal theme: `body{!important}`, `h1-h6{!important}`, `.site-footer/.site-header` backgrounds, the "strip header backdrop" block, the `a:hover/font-weight/strong/table th` overrides, and the orphan `.anchor-end` declaration. ~190 lines → ~140.
- Clean `_includes/critical.css`: drop the duplicate `scrollbar-gutter` rule, the algoprep-only colour variables (`--surface-pass/fail`, `--green/red`, `--btn-disabled-bg`, `--btn-text`, `--glass-*`, `--surface-hover/active`, `--accent-disabled`), and the `!important` on `pre/code/.highlight` that existed only to override the theme.

Net diff: 4 files, ~105 insertions / 238 deletions.

## Test plan
- [ ] Deploy succeeds.
- [ ] Visual diff Home / About / Blog landing / individual post on light & dark themes against production. No layout shift, no missing styles.
- [x] No remaining references to removed CSS vars / classes (`grep` clean).