### PR TITLE
Replace Material Symbols icon font with inline SVGs

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -53,26 +53,27 @@ code {
   font-size: 1em;
 }
 
-/* Icon helpers used by the copy-code button on first paint */
-.btn-icon {
-  height: 1.4em;
-  width: 1.4em;
-  font-size: 1.4em;
-  flex-shrink: 0;
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: .5em;
-  object-fit: contain;
-}
+/* Theme toggle icons: render the right one for the current theme up
+   front (theme-sniff sets data-theme before paint), no JS swap needed. */
+.theme-icon { display: inline-block; vertical-align: middle; }
+.theme-icon-dark { display: none; }
+[data-theme='dark'] .theme-icon-light { display: none; }
+[data-theme='dark'] .theme-icon-dark { display: inline-block; }
 
-.btn-icon-material-symbols {
-  font-size: 1.65em;
-  flex-shrink: 0;
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: .5em;
-}
+.heading-icon { vertical-align: -.2em; margin-right: .25em; }
 
 pre.copy-wrap { position: relative; }
-.copy-btn { position: absolute; top: .25em; right: .25em; background: none; border: none; color: var(--accent); cursor: pointer; padding: .2em; line-height: 1; display: flex; align-items: center; }
+.copy-btn {
+  position: absolute;
+  top: .25em;
+  right: .25em;
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: .2em;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+}
 .copy-btn[data-copied] { color: var(--accent); }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,13 +18,6 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/logos-flavicon/apple-touch-icon.png" />
     <link rel="manifest" href="/logos-flavicon/site.webmanifest" />
 
-    <!-- fonts -->
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
-    <link rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=block"
-      crossorigin>
-
     <!-- critical CSS inline -->
     <style>{% include critical.css %}</style>
 
@@ -79,7 +72,12 @@
 
           <button id="theme-toggle" class="theme-btn"
             aria-label="Toggle colour scheme">
-            <span class="material-symbols-outlined" id="theme-icon" aria-hidden="true" data-icon></span>
+            <svg class="theme-icon theme-icon-light" viewBox="0 -960 960 960" width="22" height="22" fill="currentColor" aria-hidden="true">
+              <path d="M480-120q-150 0-255-105T120-480q0-150 105-255t255-105q14 0 27.5 1t26.5 3q-41 29-65.5 75.5T444-660q0 90 63 153t153 63q55 0 101-24.5t75-65.5q2 13 3 26.5t1 27.5q0 150-105 255T480-120Zm0-80q88 0 158-48.5T740-375q-20 5-40 8t-40 3q-123 0-209.5-86.5T364-660q0-20 3-40t8-40q-78 32-126.5 102T200-480q0 116 82 198t198 82Zm-10-270Z"/>
+            </svg>
+            <svg class="theme-icon theme-icon-dark" viewBox="0 -960 960 960" width="22" height="22" fill="currentColor" aria-hidden="true">
+              <path d="M565-395q35-35 35-85t-35-85q-35-35-85-35t-85 35q-35 35-35 85t35 85q35 35 85 35t85-35Zm-226.5 56.5Q280-397 280-480t58.5-141.5Q397-680 480-680t141.5 58.5Q680-563 680-480t-58.5 141.5Q563-280 480-280t-141.5-58.5ZM200-440H40v-80h160v80Zm720 0H760v-80h160v80ZM440-760v-160h80v160h-80Zm0 720v-160h80v160h-80ZM256-650l-101-97 57-59 96 100-52 56Zm492 496-97-101 53-55 101 97-57 59Zm-98-550 97-101 59 57-100 96-56-52ZM154-212l101-97 55 53-97 101-59-57Zm326-268Z"/>
+            </svg>
           </button>
         </nav>
 
@@ -92,7 +90,9 @@
         {%- else -%}
           <div class="recent-posts">
             <h2 class="recent-heading">
-              <span class="material-symbols-outlined" aria-hidden="true" data-icon="article"></span>
+              <svg class="heading-icon" viewBox="0 -960 960 960" width="22" height="22" fill="currentColor" aria-hidden="true">
+                <path d="M280-280h280v-80H280v80Zm0-160h400v-80H280v80Zm0-160h400v-80H280v80Zm-80 480q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560H200v560Zm0-560v560-560Z"/>
+              </svg>
               Recent posts
             </h2>
 

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -110,16 +110,10 @@ hr { border-color: rgba(var(--text), .2); }
   background: none;
   border: none;
   cursor: pointer;
-  font-size: .01rem;
   color: var(--accent);
   line-height: 1;
-  transition: background 0.2s;
-}
-
-#theme-icon {
-  font-size: 1.25rem;
-  width: 1em;
-  display: inline-block;
+  transition: opacity 0.15s;
+  padding: .25em;
 }
 
 .theme-btn:hover { opacity: 0.75; }
@@ -139,29 +133,23 @@ hr { border-color: rgba(var(--text), .2); }
 }
 
 .go-blog a:hover { text-decoration: underline; }
-.go-blog .material-symbols-outlined { font-size: 1.2em; }
 
-.material-symbols-outlined {
-  display: inline-block;
-  width: 1em;
-}
-
-.anchorjs-link::after {
-  font-family: "Material Symbols Outlined";
-  content: "link";
-  font-size: 1em;
-  vertical-align: -0.15em;
+/* Heading anchor links injected by anchor-js on post pages. The icon is
+   a plain '#' character so we have no font dependency. */
+.anchorjs-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  margin-left: .25rem;
   opacity: 0;
   transition: opacity .15s ease;
-  margin-left: .25rem;
 }
 
-h1:hover .anchorjs-link::after,
-h2:hover .anchorjs-link::after,
-h3:hover .anchorjs-link::after,
-h4:hover .anchorjs-link::after,
-h5:hover .anchorjs-link::after,
-h6:hover .anchorjs-link::after {
+h1:hover .anchorjs-link,
+h2:hover .anchorjs-link,
+h3:hover .anchorjs-link,
+h4:hover .anchorjs-link,
+h5:hover .anchorjs-link,
+h6:hover .anchorjs-link {
   opacity: .6;
 }
 

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,3 +1,13 @@
+const COPY_SVG =
+  '<svg viewBox="0 -960 960 960" width="18" height="18" fill="currentColor" aria-hidden="true">' +
+  '<path d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z"/>' +
+  '</svg>';
+
+const CHECK_SVG =
+  '<svg viewBox="0 -960 960 960" width="18" height="18" fill="currentColor" aria-hidden="true">' +
+  '<path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"/>' +
+  '</svg>';
+
 export function addCopyButtons(scope = document) {
   scope.querySelectorAll('pre > code, .cm-static-view').forEach(el => {
     const pre = el.matches('pre > code') ? el.parentElement : el;
@@ -7,21 +17,18 @@ export function addCopyButtons(scope = document) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'copy-btn';
-    btn.innerHTML =
-      '<span class="material-symbols-outlined btn-icon-material-symbols" aria-hidden="true">content_copy</span>';
+    btn.innerHTML = COPY_SVG;
 
     btn.addEventListener('click', () => {
       const text = el.matches('pre > code')
-        ? el.innerText // (Consider textContent; see note below.)
+        ? el.innerText
         : el.getAttribute('data-code') || '';
       navigator.clipboard.writeText(text)
         .then(() => {
-          btn.innerHTML =
-            '<span class="material-symbols-outlined btn-icon-material-symbols" aria-hidden="true">check</span>';
+          btn.innerHTML = CHECK_SVG;
           btn.dataset.copied = 'true';
           setTimeout(() => {
-            btn.innerHTML =
-              '<span class="material-symbols-outlined btn-icon-material-symbols" aria-hidden="true">content_copy</span>';
+            btn.innerHTML = COPY_SVG;
             delete btn.dataset.copied;
           }, 2000);
         })
@@ -30,4 +37,10 @@ export function addCopyButtons(scope = document) {
 
     pre.appendChild(btn);
   });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => addCopyButtons(), { once: true });
+} else {
+  addCopyButtons();
 }

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -26,12 +26,7 @@
     if (!article) return;                     // nothing to do
 
     ensureAnchorLib().then(anchors => {
-      anchors.options = { placement: 'right', icon: '', visible: 'hover' };
-
-      /* remove any anchors Turbo carried over from the previous post */
-      anchors.remove('h1,h2,h3,h4,h5,h6', article);
-
-      /* add fresh ones for the current post */
+      anchors.options = { placement: 'right', icon: '#', visible: 'hover' };
       anchors.add('h1,h2,h3,h4,h5,h6', article);
     });
   }

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,41 +1,17 @@
-const key   = 'prefers-dark';
-const root  = document.documentElement;
-const toggle= document.getElementById('theme-toggle');
-const icon  = document.getElementById('theme-icon');
+const KEY = 'prefers-dark';
+const root = document.documentElement;
+const toggle = document.getElementById('theme-toggle');
 
-const prefers = matchMedia('(prefers-color-scheme: dark)').matches;
-const stored  = localStorage.getItem(key);
-const startDark = stored ? stored === 'true' : prefers;
-
-/* --- helpers ---------------------------------------------------- */
-function setIcon(isDark){
-  const glyph = isDark ? 'light_mode' : 'dark_mode';
-  icon.dataset.icon = glyph;     // for future paint calls
-  icon.textContent  = glyph;     // visible right now
+function applyTheme(isDark) {
+  root.dataset.theme = isDark ? 'dark' : 'light';
 }
 
-function paintMaterialIcons(scope = document){
-  scope.querySelectorAll('.material-symbols-outlined[data-icon]')
-       .forEach(el => { el.textContent = el.dataset.icon; });
-}
-
-/* --- initial boot ----------------------------------------------- */
-if (toggle && icon){
-  applyTheme(startDark);         // sets icon & html[data-theme]
-
+if (toggle) {
+  /* Initial paint already handled by theme-sniff.js. CSS picks the right
+   * SVG via [data-theme]; this listener flips the attribute on click. */
   toggle.addEventListener('click', () => {
     const next = root.dataset.theme !== 'dark';
     applyTheme(next);
-    localStorage.setItem(key, next);
-    document.dispatchEvent(new CustomEvent('themechange', { bubbles:true, composed:true }));
+    localStorage.setItem(KEY, String(next));
   });
 }
-
-/* --- theme / icon application ----------------------------------- */
-function applyTheme(isDark){
-  root.dataset.theme = isDark ? 'dark' : 'light';
-  setIcon(isDark);
-}
-
-/* --- once fonts are ready, paint all glyphs --------------------- */
-document.fonts.ready.then(paintMaterialIcons.bind(null, document));


### PR DESCRIPTION
Closes #48.

## Summary
The Material Symbols font was loaded from Google Fonts with `display=block`, so every icon (theme toggle, recent-posts heading, copy-code button) rendered as empty space until the font landed, then popped in. This was the dominant flicker on first paint.

- Inline the canonical Material Symbols Outlined SVGs (fetched from `fonts.gstatic.com`'s static endpoint) for `light_mode`, `dark_mode`, `article`, `content_copy`, `check`. Same path data Google ships in the font — visually identical.
- Drop the Google Fonts preconnect + Material Symbols stylesheet from `default.html`.
- Theme toggle renders both SVGs inside the button; CSS picks the right one via `[data-theme]` (set pre-paint by `theme-sniff`). No JS swap → zero flicker.
- `copy-code.js` swaps the copy/check SVGs on click and now self-initialises on DOMContentLoaded (was previously called from `editor.js`, which is gone).
- AnchorJS icon switches from Material's `link` glyph rendered via a `::after` with `font-family: "Material Symbols Outlined"` to a plain `#` character. Styling moves to `.anchorjs-link` itself.
- Drop `.material-symbols-outlined`, `.btn-icon-material-symbols`, `#theme-icon` CSS rules and the `paintMaterialIcons` machinery in `theme-toggle.js`.

## Test plan
- [ ] Deploy succeeds.
- [ ] On `/` and `/blog/` and an individual post: theme toggle, recent-posts heading icon, and (on a post that has code blocks — none currently) copy-code icon all render immediately on first paint with no swap-in.
- [x] `grep -rn material-symbols` clean.