### PR TITLE
Add image asset convention + linked source attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,35 @@ This repository contains the source for a Jekyll-based personal website. Below i
 - `_includes/` — Reusable partial templates and assets.
 - `_layouts/` — Page layouts. `default.html` is the base layout; `post.html` extends it for blog posts.
 - `_posts/` — Blog posts in Markdown. Each file has front-matter `layout: post`.
-- `assets/` — Static assets. Contains SCSS stylesheets under `css/` and JavaScript modules under `js/`.
+- `assets/` — Static assets. SCSS stylesheets under `css/`, JS bundle output under `js/`, images under `images/`.
+  - `assets/images/posts/<post-slug>/` — per-post images. Drop the cover image (and any inline figures used by the post) here. Keep the raw original alongside any stylized variants you ship — e.g. `cover.jpg` plus `cover.original.jpg`.
 - `blog/` — Landing page for the blog. Displays the latest post.
 - `logos-flavicon/` — Favicon and web manifest files.
+
+## Posts: cover image + attribution
+
+Every post can declare a cover image in front matter. The post layout (and the blog landing) renders it via `_includes/post-cover.html`.
+
+```yaml
+image:        /assets/images/posts/<post-slug>/cover.jpg   # local path, or external URL
+image_alt:    "Short description for screen readers"
+image_credit:
+  by:          "Photographer Name"
+  url:         https://example.com/photographer-profile     # optional
+  source:      "Unsplash"                                   # optional
+  source_url:  https://unsplash.com/photos/abc              # optional
+```
+
+Both `by` and `source` (with their optional URLs) get rendered as a single linked caption beneath the image: *Photo by **Name** on **Source***. Drop the inline `<img>` from the body — front matter is the single source of truth.
+
+For inline figures inside the body, use semantic `<figure>` markup:
+
+```html
+<figure>
+  <img src="/assets/images/posts/<slug>/diagram.png" alt="...">
+  <figcaption>Caption with <a href="...">link</a> if needed.</figcaption>
+</figure>
+```
 
 ## Maintenance
 

--- a/_includes/post-cover.html
+++ b/_includes/post-cover.html
@@ -1,0 +1,38 @@
+{%- comment -%}
+Renders a post's cover image with linked source attribution.
+
+Usage: {% include post-cover.html post=page %}  (or post=latest)
+
+Front-matter shape:
+  image:        /assets/images/posts/<slug>/cover.jpg  # or remote URL
+  image_alt:    "..."
+  image_credit:
+    by:          "Photographer Name"
+    url:         https://example.com/profile        # optional
+    source:      "Unsplash"                         # optional
+    source_url:  https://unsplash.com/photos/abc    # optional
+{%- endcomment -%}
+{%- if include.post.image -%}
+<figure class="post-cover">
+  <img src="{{ include.post.image }}"
+       alt="{{ include.post.image_alt | default: include.post.title }}"
+       loading="lazy" decoding="async">
+  {%- if include.post.image_credit -%}
+    <figcaption>
+      Photo by
+      {%- if include.post.image_credit.url %}
+        <a href="{{ include.post.image_credit.url }}" rel="noopener nofollow">{{ include.post.image_credit.by }}</a>
+      {%- else %}
+        {{ include.post.image_credit.by }}
+      {%- endif -%}
+      {%- if include.post.image_credit.source %} on
+        {%- if include.post.image_credit.source_url %}
+          <a href="{{ include.post.image_credit.source_url }}" rel="noopener nofollow">{{ include.post.image_credit.source }}</a>
+        {%- else %}
+          {{ include.post.image_credit.source }}
+        {%- endif -%}
+      {%- endif -%}
+    </figcaption>
+  {%- endif -%}
+</figure>
+{%- endif -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,16 +14,15 @@ layout: default
   </time>
 </p>
 
+{% include post-cover.html post=page %}
+
 {{ content }}
 
 {%- if page.tags and page.tags != empty -%}
-  <p class="post-tags" style="font-size:0.85em;">
+  <p class="post-tags">
     <strong><em>Keywords: </em></strong>
     {%- for tag in page.tags -%}
       <em>{{ tag }}</em>{% unless forloop.last %}&nbsp;&middot;&nbsp;{% endunless %}
     {%- endfor -%}
   </p>
 {%- endif -%}
-
-
-

--- a/_posts/2025-06-26-Path-to-working-permit-for-Swiss-graduates.md
+++ b/_posts/2025-06-26-Path-to-working-permit-for-Swiss-graduates.md
@@ -3,7 +3,12 @@ layout: post
 title: "Path to working permits for Swiss graduates"
 author: "Viktor Shcherbakov"
 image: "https://images.unsplash.com/photo-1593186344142-ef775a6e596f?w=1200&h=630&fit=crop&auto=format&q=75"
-image_alt: "Photo by Piotr Guzik, Unsplash.com"
+image_alt: "Red mountain train traversing the Swiss alps"
+image_credit:
+  by: "Piotr Guzik"
+  url: "https://unsplash.com/@piotrguzik"
+  source: "Unsplash"
+  source_url: "https://unsplash.com/photos/red-and-black-train-on-snow-covered-mountain-during-daytime-T9k5L_KKYIA"
 redirect_from:
   - /2025/06/20/Path-to-working-permit-for-Swiss-graduates.html
 description: >
@@ -21,14 +26,6 @@ tags:
   - Expat careers
   - Higher education
 ---
-
-<img src="{{ page.image }}"
-     alt="Photo by Piotr Guzik, Unsplash.com"
-     width="1200" height="630"
-     loading="lazy"
-     decoding="async">
-*Photo by Piotr Guzik / Unsplash*
-{: .img-caption }
 
 ### Disclaimer {#disclaimer}
 The author is not a lawyer, and not even a German-speaker. The information here is compiled from personal notes of the 

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -134,6 +134,65 @@ li { margin: 0.25em 0; }
 }
 .post-tags em { font-style: normal; color: var(--text-muted); }
 
+/* --- Post cover image with linked source attribution --- */
+.post-cover {
+  margin: 1.75em 0 2.25em;
+}
+.post-cover img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+  margin: 0;
+}
+.post-cover figcaption {
+  margin-top: 0.45em;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+  line-height: 1.5;
+}
+.post-cover figcaption a,
+.post-cover figcaption a:visited {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--border);
+  text-underline-offset: 2px;
+}
+.post-cover figcaption a:hover {
+  color: var(--accent);
+  text-decoration-color: currentColor;
+}
+
+/* Inline figures inside post body (when content uses <figure> directly) */
+.post-content figure {
+  margin: 1.75em 0;
+}
+.post-content figure img {
+  margin: 0;
+  border-radius: 6px;
+}
+.post-content figure figcaption {
+  margin-top: 0.45em;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+  line-height: 1.5;
+}
+.post-content figure figcaption a,
+.post-content figure figcaption a:visited {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--border);
+  text-underline-offset: 2px;
+}
+.post-content figure figcaption a:hover {
+  color: var(--accent);
+  text-decoration-color: currentColor;
+}
+
 /* --- Heading anchors (anchor-js) --- */
 .anchorjs-link {
   color: var(--text-muted);

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: default
 permalink: /blog/
 ---
 {% assign latest = site.posts | first %}
@@ -17,10 +17,12 @@ permalink: /blog/
   </time>
 </p>
 
+{% include post-cover.html post=latest %}
+
 {{ latest.content }}
 
 {%- if latest.tags and latest.tags != empty -%}
-  <p class="post-tags" style="font-size:0.85em;">
+  <p class="post-tags">
     <strong><em>Keywords: </em></strong>
     {%- for tag in latest.tags -%}
       <em>{{ tag }}</em>{% unless forloop.last %}&nbsp;&middot;&nbsp;{% endunless %}


### PR DESCRIPTION
## Summary
- New `_includes/post-cover.html` partial renders a post's cover image + a *Photo by <Name> on <Source>* caption with optional per-credit links.
- Post layout and `/blog/` landing both call the partial — single rendering path, no duplication.
- Front-matter shape:
  ```yaml
  image:        /assets/images/posts/<slug>/cover.jpg   # or external URL
  image_alt:    "Short alt"
  image_credit:
    by:          "Photographer Name"
    url:         https://example.com/profile        # optional
    source:      "Unsplash"                         # optional
    source_url:  https://unsplash.com/photos/abc    # optional
  ```
- The existing Swiss-permits post: inline `<img>` removed from body; credit moved to structured front matter with profile + photo links.
- New convention: per-post images live under `assets/images/posts/<post-slug>/`. Directory seeded with `.gitkeep`.
- CSS for `.post-cover figure` and inline `.post-content figure` — small italic centered caption; muted underline links that highlight on hover.
- Convention documented in `AGENTS.md`.

## Where to put stylized images
Drop them in `assets/images/posts/<post-slug>/`. Cover image goes in there as e.g. `cover.jpg`. If you keep raw originals around, name them `cover.original.jpg` (or similar suffix) so the published name is the stylized one.