### PR TITLE
SEO cleanup: sitemap, per-page meta, stable Person @id

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,14 @@
 title: Viktor Shcherbakov
 tagline: Machine Learning Engineer
 description: >-
-  This is a personal website where I write about my experience, thoughts and share
-  potentially useful information.
+  Personal site of Viktor Shcherbakov — Machine Learning Engineer based in Switzerland.
+  Long-form notes on ML, software, and the practical side of working in Switzerland as
+  a non-EU graduate.
 url: "https://viktor-shcherb.github.io"
 baseurl: ""
 logo: /logos-flavicon/favicon-96x96.png
+# Default Open Graph / Twitter card image for pages without an explicit `image:`.
+image: /logos-flavicon/web-app-manifest-512x512.png
 author: Viktor Shcherbakov
 github:
   username: viktor-shcherb
@@ -26,10 +29,29 @@ sass:
   load_paths:
     - assets/css
 
+# Hide developer docs and tool config from the published site so they
+# don't end up in /AGENTS/, /README/, etc. and pollute the sitemap.
+exclude:
+  - AGENTS.md
+  - README.md
+  - LICENSE
+  - Gemfile
+  - Gemfile.lock
+  - package.json
+  - package-lock.json
+  - tsconfig.json
+  - scripts/
+  - src/
+  - vendor/
+  - node_modules/
+  - .bundle/
+  - .sass-cache/
+  - .jekyll-cache/
+
 feed:
   path: feed.xml
   title: "Viktor Shcherbakov — Blog"
-  description: "The theme of the blog is to be defined, but you are welcome to have a look around!"
+  description: "Long-form notes on ML, software, and the practical side of life and work in Switzerland."
   lang: en-US
   author_name: Viktor Shcherbakov
   author_url: https://viktor-shcherb.github.io/about/

--- a/_includes/person-schema.html
+++ b/_includes/person-schema.html
@@ -1,11 +1,15 @@
-{% comment %}
-Outputs JSON-LD only on pages whose front-matter sets schema: person
-{% endcomment %}
-{% if page.schema == 'person' %}
+{%- comment -%}
+Person schema. Rendered on the home page and on any page whose front-matter
+sets `schema: person`. The stable @id lets other JSON-LD blocks (post
+authors, WebSite.author) reference the same entity.
+{%- endcomment -%}
+{%- if page.home or page.schema == 'person' -%}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Person",
+  "@id": "{{ site.url }}/#viktor",
+  "mainEntityOfPage": "{{ '/about/' | absolute_url }}",
 
   "name": "Viktor Shcherbakov",
   "givenName": "Viktor",
@@ -13,7 +17,7 @@ Outputs JSON-LD only on pages whose front-matter sets schema: person
   "alternateName": "Viktor Scherbakov",
   "jobTitle": "Machine-Learning Engineer",
   "description": "Machine-learning engineer based in Switzerland.",
-  "url": "https://viktor-shcherb.github.io/about/",
+  "url": "{{ site.url }}/",
 
   "address": {
     "@type": "PostalAddress",
@@ -22,8 +26,8 @@ Outputs JSON-LD only on pages whose front-matter sets schema: person
   },
 
   "birthPlace": {
-    "@type":"City",
-    "name":"Moscow"
+    "@type": "City",
+    "name": "Moscow"
   },
 
   "image": {
@@ -45,7 +49,6 @@ Outputs JSON-LD only on pages whose front-matter sets schema: person
       "name": "University of Geneva",
       "url": "https://www.unige.ch/en/"
     },
-
     {
       "@type": "CollegeOrUniversity",
       "name": "Lomonosov Moscow State University",
@@ -75,4 +78,4 @@ Outputs JSON-LD only on pages whose front-matter sets schema: person
   ]
 }
 </script>
-{% endif %}
+{%- endif -%}

--- a/about.md
+++ b/about.md
@@ -1,14 +1,15 @@
 ---
 layout: default
-title: "About me"
+title: "About"
+description: "Machine-learning engineer based in Geneva, Switzerland. Alumnus of the University of Geneva and Lomonosov Moscow State University."
 permalink: /about/
-image: "https://github.com/viktor-shcherb.png?size=480"
-image_alt: "Viktor Shcherbakov"
+image: "https://github.com/viktor-shcherb.png?size=600"
+image_alt: "Photograph of Viktor Shcherbakov"
 schema: person
 ---
 
 <img src="https://github.com/viktor-shcherb.png?size=480"
-     alt="Picture of Viktor"
+     alt="Photograph of Viktor Shcherbakov"
      class="avatar"
      width="240" height="240"
      loading="lazy"

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,9 +1,12 @@
 ---
 layout: default
 permalink: /blog/
+title: "Blog"
+description: "Latest post by Viktor Shcherbakov."
+sitemap: false
 ---
 {% assign latest = site.posts | first %}
-<link rel="canonical" href="{{ latest.url | absolute_url }}">
+<meta name="robots" content="noindex, follow">
 
 <h1>{{ latest.title }}</h1>
 <p class="post-meta">

--- a/google25034fb35aed61ef.html
+++ b/google25034fb35aed61ef.html
@@ -1,1 +1,5 @@
+---
+sitemap: false
+permalink: /google25034fb35aed61ef.html
+---
 google-site-verification: google25034fb35aed61ef.html

--- a/index.md
+++ b/index.md
@@ -1,8 +1,11 @@
 ---
 layout: default
-title: "Home"
+title: "Viktor Shcherbakov"
+description: "Personal site of Viktor Shcherbakov, a machine-learning engineer based in Switzerland. Long-form notes on ML, software, and the practical side of working in Switzerland as a non-EU graduate."
+image: /logos-flavicon/web-app-manifest-512x512.png
+image_alt: "Viktor Shcherbakov stamp logo"
 permalink: /
-home: true 
+home: true
 ---
 
 Welcome — long-form thoughts and projects, slowly.

--- a/robots.txt
+++ b/robots.txt
@@ -1,1 +1,4 @@
+User-agent: *
+Allow: /
+
 Sitemap: https://viktor-shcherb.github.io/sitemap.xml


### PR DESCRIPTION
## Sitemap pollution (the headline issue)
Pre-fix sitemap had `/AGENTS/`, `/blog/`, and the GSC verification HTML in it.

- Stop publishing dev docs as pages. New `exclude:` list in `_config.yml` covers `AGENTS.md`, `README.md`, `LICENSE`, `Gemfile*`, `package*.json`, `tsconfig.json`, `scripts/`, `src/`, `vendor/`, `node_modules/`, `.bundle/`, `.sass-cache/`, `.jekyll-cache/`. `/AGENTS/` is gone from the live site.
- `/blog/` gets `noindex, follow` and `sitemap: false`. It is a duplicate of the latest post body so we don't want it indexed; drop the manual `<link rel="canonical">` that was conflicting with jekyll-seo-tag's auto-canonical.
- `google2503*.html` gets `sitemap: false` plus an explicit `permalink:` so it stays at the exact URL Google verified.

Resulting sitemap is just: `/`, `/about/`, and the two posts.

## Per-page meta
- Home: clean title (no double "Viktor Shcherbakov | Viktor Shcherbakov"), specific description, `og:image` set.
- About: title shortened to "About"; specific description.
- Site description rewritten to match actual topics (ML, software, Swiss-grad practicals).

## Structured data
- `_includes/person-schema.html` now renders on the home page too (was about-only). Stable `@id` of `<site>/#viktor` so future blocks (post authors, WebSite.author) can reference the same Person. Added `mainEntityOfPage`.
- Posts already get BlogPosting from jekyll-seo-tag.

## robots.txt
Added explicit `User-agent: *` / `Allow: /`. Some crawlers refuse a robots.txt with only a `Sitemap:` directive.

## Re "couldn't fetch" in GSC
The sitemap responded HTTP 200 with valid XML and `application/xml` content-type before this PR — Google's "couldn't fetch" is most often queue lag after submission, not a server-side failure. The cleanups here reduce the chance GSC discovers URLs you don't want to advertise (`/AGENTS/`, the verification HTML, the duplicate `/blog/`).

Re-submit the sitemap in GSC after this deploy lands and the queue should clear within a day or two.