### PR TITLE
Footer social links: GitHub, LinkedIn, ORCID, Google Scholar

### DIFF
--- a/_includes/person-schema.html
+++ b/_includes/person-schema.html
@@ -72,9 +72,10 @@ authors, WebSite.author) reference the same entity.
 
   "sameAs": [
     "https://github.com/viktor-shcherb",
-    "https://www.linkedin.com/in/viktoroo/",
-    "https://mastodon.social/@viktor_shcherb",
-    "https://orcid.org/0000-0003-1098-9548"
+    "https://www.linkedin.com/in/viktor-shcherb/",
+    "https://orcid.org/0000-0003-1098-9548",
+    "https://scholar.google.com/citations?user=WA2IuM4AAAAJ&hl=en",
+    "https://mastodon.social/@viktor_shcherb"
   ]
 }
 </script>

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -1,0 +1,36 @@
+{%- comment -%}
+Social links rendered in the site footer. Each link wraps an inline SVG so
+icons inherit text colour via `fill="currentColor"` and theme cleanly.
+GitHub / ORCID / Google Scholar paths are from simple-icons (CC0); LinkedIn
+is a hand-written path (LinkedIn brand-restricted theirs out of simple-icons).
+{%- endcomment -%}
+<ul class="social-links" aria-label="Social profiles">
+  <li>
+    <a href="https://github.com/viktor-shcherb" rel="me noopener" aria-label="GitHub">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+      </svg>
+    </a>
+  </li>
+  <li>
+    <a href="https://www.linkedin.com/in/viktor-shcherb/" rel="me noopener" aria-label="LinkedIn">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
+      </svg>
+    </a>
+  </li>
+  <li>
+    <a href="https://orcid.org/0000-0003-1098-9548" rel="me noopener" aria-label="ORCID">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M12 0C5.372 0 0 5.372 0 12s5.372 12 12 12 12-5.372 12-12S18.628 0 12 0zM7.369 4.378c.525 0 .947.431.947.947s-.422.947-.947.947a.95.95 0 0 1-.947-.947c0-.525.422-.947.947-.947zm-.722 3.038h1.444v10.041H6.647V7.416zm3.562 0h3.9c3.712 0 5.344 2.653 5.344 5.025 0 2.578-2.016 5.025-5.325 5.025h-3.919V7.416zm1.444 1.303v7.444h2.297c3.272 0 4.022-2.484 4.022-3.722 0-2.016-1.284-3.722-4.097-3.722h-2.222z"/>
+      </svg>
+    </a>
+  </li>
+  <li>
+    <a href="https://scholar.google.com/citations?user=WA2IuM4AAAAJ&hl=en" rel="me noopener" aria-label="Google Scholar">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M5.242 13.769L0 9.5 12 0l12 9.5-5.242 4.269C17.548 11.249 14.978 9.5 12 9.5c-2.977 0-5.548 1.748-6.758 4.269zM12 10a7 7 0 1 0 0 14 7 7 0 0 0 0-14z"/>
+      </svg>
+    </a>
+  </li>
+</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -107,6 +107,7 @@
       </section>
 
       <footer class="site-footer">
+        {% include social-links.html %}
         <p>© {{ 'now' | date: "%Y" }} {{ site.author }} · <a href="https://github.com/{{ site.github.username }}/{{ site.github.repository_name | default: 'viktor-shcherb.github.io' }}">source</a></p>
       </footer>
     </div>

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -253,6 +253,33 @@ img.avatar {
 .site-footer a:visited { color: var(--text-muted); text-decoration: underline; text-decoration-color: var(--border); }
 .site-footer a:hover { color: var(--accent); text-decoration-color: currentColor; }
 
+/* --- Social links row in footer --- */
+.social-links {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.9rem;
+  display: flex;
+  justify-content: center;
+  gap: 1.1rem;
+}
+.social-links a,
+.social-links a:visited {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color .15s ease, transform .15s ease;
+}
+.social-links a:hover,
+.social-links a:focus-visible {
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+.social-links svg { display: block; }
+
 /* --- Tables (rare in posts) --- */
 table {
   width: 100%;


### PR DESCRIPTION
## Summary
- New `_includes/social-links.html` partial — one inline-SVG link per profile, SVGs use `fill="currentColor"` so they inherit footer text colour and pop to `--accent` on hover. Light + dark themes both work cleanly.
- Footer renders the partial above the © line.
- GitHub / ORCID / Google Scholar paths from simple-icons (CC0); LinkedIn path is hand-written (LinkedIn is brand-restricted out of simple-icons).
- Person schema's `sameAs` updated to match the same set: replace the old `/viktoroo` LinkedIn URL with `/viktor-shcherb`, add Google Scholar.

## Visual
Verified locally: footer shows GitHub, LinkedIn, ORCID, Google Scholar icons centered above the © line in both themes.