### PR TITLE
Archive thumbnails, sticky footer, drop duplicate border

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -46,9 +46,16 @@ body {
 .wrapper {
   max-width: 38rem;
   margin-inline: auto;
-  padding: 2.5rem 1.5rem 4rem;
+  padding: 2.5rem 1.5rem 2.5rem;
   position: relative;
+
+  /* Sticky footer: short pages still pin the footer to the viewport bottom. */
+  min-height: 100vh;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
+.wrapper > section { flex: 1 0 auto; }
 
 /* --- Header --- */
 header.site-header {

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -249,14 +249,36 @@ img.avatar {
   margin: 1.5rem 0 0;
 }
 .archive-entry {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-start;
   padding: 1.5rem 0;
   border-top: 1px solid var(--border);
 }
-.archive-entry:last-child { border-bottom: 1px solid var(--border); }
+.archive-entry-cover {
+  flex: 0 0 9rem;
+  display: block;
+  border-radius: 4px;
+  overflow: hidden;
+  line-height: 0;
+}
+.archive-entry-cover img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  display: block;
+  transition: transform .2s ease;
+}
+.archive-entry-cover:hover img { transform: scale(1.02); }
+.archive-entry-text {
+  flex: 1 1 0;
+  min-width: 0;
+}
 .archive-entry-title {
   font-size: 1.25rem;
   margin: 0 0 0.25rem;
   letter-spacing: -0.01em;
+  line-height: 1.25;
 }
 .archive-entry-title a,
 .archive-entry-title a:visited {
@@ -276,6 +298,11 @@ img.avatar {
   color: var(--text-muted);
   font-size: 0.96rem;
   line-height: 1.55;
+}
+
+@media (max-width: 30rem) {
+  .archive-entry { flex-direction: column; gap: 0.85rem; }
+  .archive-entry-cover { flex: none; width: 100%; }
 }
 
 /* --- Footer --- */

--- a/blog/index.md
+++ b/blog/index.md
@@ -14,15 +14,22 @@ description: "All posts by Viktor Shcherbakov — long-form notes on ML, softwar
   <ol class="archive-list">
   {%- for post in visible_posts -%}
     <li class="archive-entry">
-      <h2 class="archive-entry-title">
-        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      </h2>
-      <p class="archive-entry-meta">
-        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
-      </p>
-      {%- if post.description -%}
-        <p class="archive-entry-desc">{{ post.description | strip_newlines | strip }}</p>
+      {%- if post.image -%}
+        <a class="archive-entry-cover" href="{{ post.url | relative_url }}" aria-hidden="true" tabindex="-1">
+          <img src="{{ post.image }}" alt="" loading="lazy" decoding="async">
+        </a>
       {%- endif -%}
+      <div class="archive-entry-text">
+        <h2 class="archive-entry-title">
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        </h2>
+        <p class="archive-entry-meta">
+          <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
+        </p>
+        {%- if post.description -%}
+          <p class="archive-entry-desc">{{ post.description | strip_newlines | strip }}</p>
+        {%- endif -%}
+      </div>
     </li>
   {%- endfor -%}
   </ol>


### PR DESCRIPTION
## Visual polish
- `/blog/` archive entries now show the post cover as a thumbnail on the left (9rem wide on desktop; full-width above the text on viewports under 30rem). Subtle hover-scale.
- Drop the duplicate divider at the bottom of the archive (was: archive-entry `:last-child border-bottom` stacked with footer `border-top` 4rem below it).
- Sticky footer: short pages (`/about/`) no longer have the footer floating mid-viewport. `.wrapper` is now a flex column with `min-height: 100vh`; `.wrapper > section { flex: 1 0 auto }` expands the body so the footer pins to the bottom.

## Verified
Light + dark, full-page screenshots of `/`, `/about/`, `/blog/`, both posts. Archive thumbnails align cleanly to the title baseline, no duplicate borders, footer pins to viewport bottom on short pages.