### PR TITLE
Archive cards: full-width landscape covers

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -249,36 +249,29 @@ img.avatar {
   margin: 1.5rem 0 0;
 }
 .archive-entry {
-  display: flex;
-  gap: 1.25rem;
-  align-items: flex-start;
-  padding: 1.5rem 0;
+  display: block;
+  padding: 1.75rem 0 2rem;
   border-top: 1px solid var(--border);
 }
 .archive-entry-cover {
-  flex: 0 0 9rem;
   display: block;
-  border-radius: 4px;
+  margin: 0 0 1.1rem;
+  border-radius: 6px;
   overflow: hidden;
   line-height: 0;
 }
 .archive-entry-cover img {
   width: 100%;
-  aspect-ratio: 16 / 10;
-  object-fit: cover;
+  height: auto;
   display: block;
-  transition: transform .2s ease;
+  transition: transform .25s ease;
 }
-.archive-entry-cover:hover img { transform: scale(1.02); }
-.archive-entry-text {
-  flex: 1 1 0;
-  min-width: 0;
-}
+.archive-entry-cover:hover img { transform: scale(1.015); }
 .archive-entry-title {
-  font-size: 1.25rem;
-  margin: 0 0 0.25rem;
-  letter-spacing: -0.01em;
-  line-height: 1.25;
+  font-size: 1.4rem;
+  margin: 0 0 0.3rem;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
 }
 .archive-entry-title a,
 .archive-entry-title a:visited {
@@ -288,7 +281,7 @@ img.avatar {
 .archive-entry-title a:hover,
 .archive-entry-title a:focus-visible { color: var(--accent); }
 .archive-entry-meta {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.6rem;
   font-size: 0.85rem;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
@@ -297,12 +290,7 @@ img.avatar {
   margin: 0;
   color: var(--text-muted);
   font-size: 0.96rem;
-  line-height: 1.55;
-}
-
-@media (max-width: 30rem) {
-  .archive-entry { flex-direction: column; gap: 0.85rem; }
-  .archive-entry-cover { flex: none; width: 100%; }
+  line-height: 1.6;
 }
 
 /* --- Footer --- */

--- a/blog/index.md
+++ b/blog/index.md
@@ -19,17 +19,15 @@ description: "All posts by Viktor Shcherbakov — long-form notes on ML, softwar
           <img src="{{ post.image }}" alt="" loading="lazy" decoding="async">
         </a>
       {%- endif -%}
-      <div class="archive-entry-text">
-        <h2 class="archive-entry-title">
-          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        </h2>
-        <p class="archive-entry-meta">
-          <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
-        </p>
-        {%- if post.description -%}
-          <p class="archive-entry-desc">{{ post.description | strip_newlines | strip }}</p>
-        {%- endif -%}
-      </div>
+      <h2 class="archive-entry-title">
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      </h2>
+      <p class="archive-entry-meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
+      </p>
+      {%- if post.description -%}
+        <p class="archive-entry-desc">{{ post.description | strip_newlines | strip }}</p>
+      {%- endif -%}
     </li>
   {%- endfor -%}
   </ol>


### PR DESCRIPTION
Drop the cramped 9 rem thumbnail-on-the-left layout; covers are 1600×840 landscape and got crushed. Switch each archive entry to a vertical card: cover at full column width with natural aspect ratio, title slightly larger on the line below, then date and description. Title 1.4rem with tighter leading since it's the dominant text on the card now.