### PR TITLE
Archive cards: text overlaid on cover with palette gradient

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -248,49 +248,73 @@ img.avatar {
   padding: 0;
   margin: 1.5rem 0 0;
 }
+.archive-list { list-style: none; padding: 0; margin: 1.5rem 0 0; }
+
+/* Archive cards: cover image with text overlaid on a palette gradient.
+   The gradient fades to var(--bg) so text reads against the cream paper
+   in light mode and against the warm-near-black in dark mode. */
 .archive-entry {
+  position: relative;
   display: block;
-  padding: 1.75rem 0 2rem;
-  border-top: 1px solid var(--border);
+  margin: 1.25rem 0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .06);
+  transition: transform .25s ease, box-shadow .25s ease;
+}
+.archive-entry:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, .12);
+}
+.archive-entry-link,
+.archive-entry-link:visited {
+  display: block;
+  color: inherit;
+  text-decoration: none;
 }
 .archive-entry-cover {
   display: block;
-  margin: 0 0 1.1rem;
-  border-radius: 6px;
-  overflow: hidden;
-  line-height: 0;
-}
-.archive-entry-cover img {
   width: 100%;
   height: auto;
-  display: block;
-  transition: transform .25s ease;
+  aspect-ratio: 1600 / 840;
+  object-fit: cover;
+  transition: transform .35s ease;
 }
-.archive-entry-cover:hover img { transform: scale(1.015); }
+.archive-entry:hover .archive-entry-cover { transform: scale(1.02); }
+.archive-entry-content {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 5.5rem 1.4rem 1.3rem;
+  background: linear-gradient(
+    to top,
+    var(--bg) 0%,
+    color-mix(in srgb, var(--bg) 92%, transparent) 35%,
+    color-mix(in srgb, var(--bg) 50%, transparent) 70%,
+    transparent 100%
+  );
+  color: var(--text);
+}
 .archive-entry-title {
-  font-size: 1.4rem;
+  font-size: 1.45rem;
   margin: 0 0 0.3rem;
+  color: var(--text);
   letter-spacing: -0.015em;
   line-height: 1.2;
+  font-weight: 600;
 }
-.archive-entry-title a,
-.archive-entry-title a:visited {
-  color: var(--text);
-  text-decoration: none;
-}
-.archive-entry-title a:hover,
-.archive-entry-title a:focus-visible { color: var(--accent); }
 .archive-entry-meta {
-  margin: 0 0 0.6rem;
-  font-size: 0.85rem;
+  margin: 0 0 0.4rem;
+  font-size: 0.82rem;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
 }
 .archive-entry-desc {
   margin: 0;
   color: var(--text-muted);
-  font-size: 0.96rem;
-  line-height: 1.6;
+  font-size: 0.93rem;
+  line-height: 1.55;
 }
 
 /* --- Footer --- */

--- a/blog/index.md
+++ b/blog/index.md
@@ -14,20 +14,20 @@ description: "All posts by Viktor Shcherbakov — long-form notes on ML, softwar
   <ol class="archive-list">
   {%- for post in visible_posts -%}
     <li class="archive-entry">
-      {%- if post.image -%}
-        <a class="archive-entry-cover" href="{{ post.url | relative_url }}" aria-hidden="true" tabindex="-1">
-          <img src="{{ post.image }}" alt="" loading="lazy" decoding="async">
-        </a>
-      {%- endif -%}
-      <h2 class="archive-entry-title">
-        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      </h2>
-      <p class="archive-entry-meta">
-        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
-      </p>
-      {%- if post.description -%}
-        <p class="archive-entry-desc">{{ post.description | strip_newlines | strip }}</p>
-      {%- endif -%}
+      <a class="archive-entry-link" href="{{ post.url | relative_url }}">
+        {%- if post.image -%}
+          <img class="archive-entry-cover" src="{{ post.image }}" alt="" loading="lazy" decoding="async">
+        {%- endif -%}
+        <div class="archive-entry-content">
+          <h2 class="archive-entry-title">{{ post.title }}</h2>
+          <p class="archive-entry-meta">
+            <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
+          </p>
+          {%- if post.description -%}
+            <p class="archive-entry-desc">{{ post.description | strip_newlines | strip }}</p>
+          {%- endif -%}
+        </div>
+      </a>
     </li>
   {%- endfor -%}
   </ol>


### PR DESCRIPTION
Variant B from the side-by-side comparison: full-bleed cover with title/date/description overlaid on the bottom over a gradient that fades to var(--bg). Light mode gradient blends with the cream stamp covers; dark mode gives white-on-warm-black contrast. Whole card is a single anchor; cover scales subtly on hover, card lifts 1 px with a soft shadow.