### PR TITLE
Fix archive-card top gap + custom domain vshcherbakov.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+vshcherbakov.com

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: >-
   Personal site of Viktor Shcherbakov — Machine Learning Engineer based in Switzerland.
   Long-form notes on ML, software, and the practical side of working in Switzerland as
   a non-EU graduate.
-url: "https://viktor-shcherb.github.io"
+url: "https://vshcherbakov.com"
 baseurl: ""
 logo: /logos-flavicon/favicon-96x96.png
 # Default Open Graph / Twitter card image for pages without an explicit `image:`.
@@ -54,5 +54,5 @@ feed:
   description: "Long-form notes on ML, software, and the practical side of life and work in Switzerland."
   lang: en-US
   author_name: Viktor Shcherbakov
-  author_url: https://viktor-shcherb.github.io/about/
+  author_url: https://vshcherbakov.com/about/
   full_content: true

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -262,6 +262,11 @@ img.avatar {
   background: var(--surface);
   box-shadow: 0 1px 2px rgba(0, 0, 0, .06);
   transition: transform .25s ease, box-shadow .25s ease;
+  /* Collapse any inline whitespace inside the <li> so the cover image
+     sits flush against the card's top edge. The text inside
+     .archive-entry-content restores font-size / line-height. */
+  font-size: 0;
+  line-height: 0;
 }
 .archive-entry:hover {
   transform: translateY(-1px);
@@ -294,6 +299,9 @@ img.avatar {
     transparent 100%
   );
   color: var(--text);
+  /* Restore type defaults that .archive-entry zeroed out for layout. */
+  font-size: 1rem;
+  line-height: 1.6;
 }
 .archive-entry-title {
   font-size: 1.45rem;


### PR DESCRIPTION
Two fixes. 1) Cover sat ~24 px below the card's rounded top edge because of an empty whitespace text-line between the li and the inner a; collapse with font-size: 0; line-height: 0 on .archive-entry, restore on .archive-entry-content. 2) Custom domain: add CNAME with vshcherbakov.com so the GH Pages config persists in the repo, update site.url in _config.yml so sitemap, jekyll-seo-tag canonicals, og:url, JSON-LD @id and feed.author_url all derive from the new domain.