### PR TITLE
Fix archive-card hover bleed

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -258,15 +258,22 @@ img.avatar {
   display: block;
   margin: 1.25rem 0;
   border-radius: 8px;
-  overflow: hidden;
   background: var(--surface);
   box-shadow: 0 1px 2px rgba(0, 0, 0, .06);
-  transition: transform .25s ease, box-shadow .25s ease;
+  transition: box-shadow .25s ease, transform .25s ease;
   /* Collapse any inline whitespace inside the <li> so the cover image
-     sits flush against the card's top edge. The text inside
-     .archive-entry-content restores font-size / line-height. */
+     sits flush against the card's top edge. .archive-entry-content
+     restores font-size / line-height for its own text. */
   font-size: 0;
   line-height: 0;
+  /* Clip in two ways: clip-path is the authoritative clip that respects
+     transformed children (Chrome/Safari leak the scaled image's bottom
+     edge past plain `overflow:hidden` + `border-radius`). isolation
+     gives us our own stacking context. */
+  overflow: hidden;
+  clip-path: inset(0 round 8px);
+  isolation: isolate;
+  will-change: transform;
 }
 .archive-entry:hover {
   transform: translateY(-1px);


### PR DESCRIPTION
Scaled cover bled past the card's rounded bottom edge on hover. Add clip-path: inset(0 round 8px) plus isolation: isolate and will-change: transform so the parent's clip is enforced even on transformed children.