### PR TITLE
Drop archive cover scale-on-hover; line artefact gone

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -291,9 +291,7 @@ img.avatar {
   height: auto;
   aspect-ratio: 1600 / 840;
   object-fit: cover;
-  transition: transform .35s ease;
 }
-.archive-entry:hover .archive-entry-cover { transform: scale(1.02); }
 .archive-entry-content {
   position: absolute;
   inset: auto 0 0 0;


### PR DESCRIPTION
Cover scale (1.02 on hover) was bleeding past clip-path on dark theme as a 1px cream sliver below the card. Drop the scale; card-lift + shadow alone are enough hover feedback. Clip-path / isolation / will-change stay as future-proofing.