### PR TITLE
Custom Atom feed honouring hidden flag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,9 +22,10 @@ permalink: /:year/:month/:day/:title/
 plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
-  - jekyll-feed
   - jekyll-redirect-from
   - jekyll-avatar
+# jekyll-feed removed — replaced by the custom feed.xml at the repo root
+# so we can honour the per-post `hidden: true` flag.
 sass:
   load_paths:
     - assets/css
@@ -49,10 +50,8 @@ exclude:
   - .jekyll-cache/
 
 feed:
-  path: feed.xml
   title: "Viktor Shcherbakov — Blog"
   description: "Long-form notes on ML, software, and the practical side of life and work in Switzerland."
   lang: en-US
   author_name: Viktor Shcherbakov
   author_url: https://vshcherbakov.com/about/
-  full_content: true

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -33,4 +33,11 @@ is a hand-written path (LinkedIn brand-restricted theirs out of simple-icons).
       </svg>
     </a>
   </li>
+  <li>
+    <a href="{{ '/feed.xml' | relative_url }}" rel="alternate" type="application/atom+xml" aria-label="RSS feed">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20A2.18 2.18 0 0 1 4 17.82a2.18 2.18 0 0 1 2.18-2.18zM4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44zm0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/>
+      </svg>
+    </a>
+  </li>
 </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,6 +29,9 @@
     <noscript><link rel="stylesheet"
           href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"></noscript>
 
+    <!-- feed auto-discovery -->
+    <link rel="alternate" type="application/atom+xml" title="{{ site.feed.title | default: site.title }}" href="{{ '/feed.xml' | absolute_url }}">
+
     <!-- structured information about blog owner -->
     {% include person-schema.html %}
 

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,44 @@
+---
+layout: null
+permalink: /feed.xml
+sitemap: false
+---
+{%- assign visible_posts = site.posts | where_exp: "p", "p.hidden != true" -%}
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ site.feed.lang | default: site.locale | default: 'en' }}">
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ '/feed.xml' | absolute_url }}" rel="self" type="application/atom+xml" />
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html" hreflang="{{ site.feed.lang | default: site.locale | default: 'en' }}" />
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ '/' | absolute_url | xml_escape }}</id>
+  <title type="html">{{ site.feed.title | default: site.title | smartify | xml_escape }}</title>
+  <subtitle>{{ site.feed.description | default: site.description | strip_newlines | strip | xml_escape }}</subtitle>
+  <author>
+    <name>{{ site.feed.author_name | default: site.author }}</name>
+    {%- if site.feed.author_url %}
+    <uri>{{ site.feed.author_url }}</uri>
+    {%- endif %}
+  </author>
+  {%- for post in visible_posts %}
+  <entry>
+    <title type="html">{{ post.title | smartify | xml_escape }}</title>
+    <link href="{{ post.url | absolute_url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
+    <published>{{ post.date | date_to_xmlschema }}</published>
+    <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
+    <id>{{ post.id | absolute_url | xml_escape }}</id>
+    <author>
+      <name>{{ post.author | default: site.author }}</name>
+    </author>
+    {%- if post.description %}
+    <summary type="html">{{ post.description | strip_newlines | strip | xml_escape }}</summary>
+    {%- endif %}
+    {%- if post.image %}
+    <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ post.image | absolute_url }}" />
+    {%- endif %}
+    {%- for tag in post.tags %}
+    <category term="{{ tag | xml_escape }}" />
+    {%- endfor %}
+    <content type="html" xml:base="{{ post.url | absolute_url }}">{{ post.content | strip | xml_escape }}</content>
+  </entry>
+  {%- endfor %}
+</feed>


### PR DESCRIPTION
Replace jekyll-feed with a 40-line custom feed.xml so we can filter posts with hidden: true. Add auto-discovery <link> in <head> and a footer RSS icon next to the social links.