### PR TITLE
Fix post-tags padding + canonical RSS SVG

### DIFF
--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -36,7 +36,7 @@ is a hand-written path (LinkedIn brand-restricted theirs out of simple-icons).
   <li>
     <a href="{{ '/feed.xml' | relative_url }}" rel="alternate" type="application/atom+xml" aria-label="RSS feed">
       <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
-        <path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20A2.18 2.18 0 0 1 4 17.82a2.18 2.18 0 0 1 2.18-2.18zM4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44zm0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/>
+        <path d="M19.199 24C19.199 13.467 10.533 4.8 0 4.8V0c13.165 0 24 10.835 24 24h-4.801zM3.291 17.415c1.814 0 3.293 1.479 3.293 3.295 0 1.813-1.485 3.29-3.301 3.29C1.47 24 0 22.526 0 20.71s1.475-3.294 3.291-3.295zM15.909 24h-4.665c0-6.169-5.075-11.245-11.244-11.245V8.09c8.727 0 15.909 7.184 15.909 15.91z"/>
       </svg>
     </a>
   </li>

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -126,9 +126,7 @@ li { margin: 0.25em 0; }
 .post-meta .byline { color: var(--text); }
 
 .post-tags {
-  margin-top: 2.5em;
-  padding-top: 1.2em;
-  border-top: 1px solid var(--border);
+  margin: 3em 0 0;
   color: var(--text-muted);
   font-size: 0.85rem;
 }


### PR DESCRIPTION
Two-divider stack between keywords and footer was visually awkward; drop the .post-tags border so only the footer divider remains. Swap the RSS icon for the canonical simple-icons SVG.