### PR TITLE
Eliminate FOUC: render-blocking stylesheet

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,16 +18,16 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/logos-flavicon/apple-touch-icon.png" />
     <link rel="manifest" href="/logos-flavicon/site.webmanifest" />
 
-    <!-- critical CSS inline -->
+    <!-- Critical CSS inline (variables, layout, nav, recent-posts, code) so
+         the page is correctly styled even before the main stylesheet
+         arrives, and as a fallback if it 404s. -->
     <style>{% include critical.css %}</style>
 
-    <!-- async main stylesheet -->
-    <link rel="preload"
-          href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"
-          as="style"
-          onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet"
-          href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"></noscript>
+    <!-- Main stylesheet, render-blocking. The total CSS budget is small
+         (~10 KB), so blocking a single round-trip on cold-cache is
+         cheaper than a flash of unstyled content above the fold. -->
+    <link rel="stylesheet"
+          href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
 
     <!-- feed auto-discovery -->
     <link rel="alternate" type="application/atom+xml" title="{{ site.feed.title | default: site.title }}" href="{{ '/feed.xml' | absolute_url }}">


### PR DESCRIPTION
Above-the-fold post titles / cover figures / archive cards rely on rules that live only in the main (async-preloaded) style.css; on cold cache they painted briefly with browser defaults before the stylesheet applied. Total CSS budget is ~10 KB / ~5 KB gzipped, so block-loading it on first paint is cheaper than the flicker. Verified locally on a 200 kbps + 200 ms latency throttle: first frame is fully styled.