### PR TITLE
Project cards, home full-row hover, steeper blog gradient

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -147,27 +147,33 @@ header.site-header {
 .posts-feed {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0 -0.55rem;
   display: flex;
   flex-direction: column;
-  gap: 0.15em;
+  gap: 0;
 }
-.posts-feed li {
+.posts-feed li { display: block; padding: 0; margin: 0; }
+.posts-feed-row,
+.posts-feed-row:visited {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
   gap: 0.5em 1em;
-  padding: 0.2em 0;
-}
-.posts-feed a,
-.posts-feed a:visited {
+  padding: 0.4rem 0.55rem;
+  border-radius: 6px;
   color: var(--text);
   text-decoration: none;
-  font-weight: 500;
+  transition: background-color .15s ease;
 }
-.posts-feed a:hover,
-.posts-feed a:focus-visible { color: var(--accent); }
+.posts-feed-row:hover,
+.posts-feed-row:focus-visible {
+  background: var(--surface);
+  color: var(--text);
+}
+.posts-feed-title { font-weight: 500; }
+.posts-feed-row:hover .posts-feed-title,
+.posts-feed-row:focus-visible .posts-feed-title { color: var(--accent); }
 .posts-feed time {
   font-size: 0.85rem;
   color: var(--text-muted);

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,10 +93,12 @@
             {%- assign recent = site.posts | where_exp: "p", "p.hidden != true" -%}
             {%- for post in recent limit:5 -%}
               <li>
-                <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-                <time datetime="{{ post.date | date_to_xmlschema }}">
-                  {{ post.date | date: "%b %-d, %Y" }}
-                </time>
+                <a class="posts-feed-row" href="{{ post.url | relative_url }}">
+                  <span class="posts-feed-title">{{ post.title }}</span>
+                  <time datetime="{{ post.date | date_to_xmlschema }}">
+                    {{ post.date | date: "%b %-d, %Y" }}
+                  </time>
+                </a>
               </li>
             {%- endfor -%}
             </ul>
@@ -109,14 +111,16 @@
                 <svg class="heading-icon" viewBox="0 -960 960 960" width="14" height="14" fill="currentColor" aria-hidden="true">
                   <path d="M440-183v-274L200-596v274l240 139Zm80 0 240-139v-274L520-457v274ZM480-526l237-137-237-137-237 137 237 137ZM160-252q-19-11-29.5-29T120-321v-318q0-22 10.5-40t29.5-29l280-161q19-11 40-11t40 11l280 161q19 11 29.5 29t10.5 40v318q0 22-10.5 40T800-252L520-91q-19 11-40 11t-40-11L160-252Zm320-228Z"/>
                 </svg>
-                Projects
+                Featured projects
               </h2>
 
               <ul class="posts-feed">
               {%- for p in featured_projects -%}
                 <li>
-                  <a href="{{ p.url | relative_url }}">{{ p.title }}</a>
-                  <span class="project-tagline">{{ p.tagline }}</span>
+                  <a class="posts-feed-row" href="{{ p.url | relative_url }}">
+                    <span class="posts-feed-title">{{ p.title }}</span>
+                    <span class="project-tagline">{{ p.tagline }}</span>
+                  </a>
                 </li>
               {%- endfor -%}
               </ul>

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -293,13 +293,15 @@ img.avatar {
 .archive-entry-content {
   position: absolute;
   inset: auto 0 0 0;
-  padding: 5.5rem 1.4rem 1.3rem;
+  padding: 4.5rem 1.4rem 1.3rem;
+  /* Solid behind the text, then a steep ramp to transparent so most of
+     the cover stays visible above the panel. */
   background: linear-gradient(
     to top,
     var(--bg) 0%,
-    color-mix(in srgb, var(--bg) 92%, transparent) 35%,
-    color-mix(in srgb, var(--bg) 50%, transparent) 70%,
-    transparent 100%
+    var(--bg) 45%,
+    color-mix(in srgb, var(--bg) 60%, transparent) 65%,
+    transparent 80%
   );
   color: var(--text);
   /* Restore type defaults that .archive-entry zeroed out for layout. */
@@ -330,7 +332,7 @@ img.avatar {
 
 /* --- Home: featured projects compact list (mirrors recent posts) --- */
 .featured-projects { margin-top: 1.5rem; }
-.featured-projects .posts-feed li .project-tagline {
+.featured-projects .posts-feed-row .project-tagline {
   font-size: 0.85rem;
   color: var(--text-muted);
   white-space: normal;
@@ -339,50 +341,63 @@ img.avatar {
   min-width: 0;
 }
 
-/* --- /projects/ listing --- */
+/* --- /projects/ listing as cards (icon stamped at top, text below) --- */
 .project-list {
   list-style: none;
   padding: 0;
   margin: 1.5rem 0 0;
 }
 .project-card {
-  margin: 0;
-  border-top: 1px solid var(--border);
+  margin: 0 0 1.25rem;
+  background: var(--surface);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .06);
+  transition: transform .25s ease, box-shadow .25s ease;
+  isolation: isolate;
+  will-change: transform;
 }
-.project-card:last-child { border-bottom: 1px solid var(--border); }
+.project-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, .12);
+}
 .project-card-link,
 .post-content .project-card-link,
 .post-content .project-card-link:visited {
-  display: flex;
-  gap: 1.25rem;
-  align-items: flex-start;
-  padding: 1.5rem 0;
+  display: block;
+  padding: 1.5rem;
   text-decoration: none;
   color: var(--text);
 }
 .project-card-link * { text-decoration: none !important; }
-.project-card-logo {
-  flex: 0 0 4.5rem;
-  width: 4.5rem;
-  height: 4.5rem;
+.project-card-logo,
+.post-content .project-card-logo {
+  width: 3.75rem;
+  height: 3.75rem;
   display: block;
+  /* override .post-content img { margin: 1.4em auto } so the icon
+     stays left-aligned at the card top instead of centring */
+  margin: 0 0 1.1rem;
+  border-radius: 0;
+  max-width: none;
 }
-.project-card-text { flex: 1 1 0; min-width: 0; }
+.project-card-text { min-width: 0; }
 .project-card-title {
   display: flex;
   align-items: baseline;
   gap: 0.6rem;
   flex-wrap: wrap;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
   margin: 0 0 0.3rem;
-  line-height: 1.25;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
   color: var(--text);
 }
-.project-card-link:hover .project-card-title { color: var(--accent); }
+.project-card:hover .project-card-title { color: var(--accent); }
 .project-card-tagline {
-  margin: 0 0 0.4rem;
+  margin: 0 0 0.5rem;
   color: var(--text);
-  font-size: 0.96rem;
+  font-size: 0.98rem;
+  line-height: 1.45;
 }
 .project-card-desc {
   margin: 0;


### PR DESCRIPTION
/projects/ entries are now actual cards (surface bg + radius + shadow + hover lift) with the logo stamped at the card's top-left. Home Recent posts and Featured projects rows are wrapped in a single anchor so the whole row highlights on hover. Blog archive gradient compressed: more of the cover stays visible, panel becomes opaque sooner where the text sits.