### PR TITLE
Gradient stops: 0/20 transparent, 20-80 ramp, 80/100 solid

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -294,15 +294,14 @@ img.avatar {
   position: absolute;
   inset: auto 0 0 0;
   padding: 4.5rem 1.4rem 1.3rem;
-  /* Top 30 % of the panel is fully transparent (image shows clearly),
-     middle 30 % is the linear ramp, bottom 40 % is solid var(--bg)
-     behind the text. Stops are written `to top`, so 0 % = bottom. */
+  /* Direction `to bottom` so 0 % = top of the panel, 100 % = bottom.
+     Top 20 % transparent, 20–80 % linear ramp, bottom 20 % solid. */
   background: linear-gradient(
-    to top,
-    var(--bg) 0%,
-    var(--bg) 40%,
-    transparent 70%,
-    transparent 100%
+    to bottom,
+    transparent 0%,
+    transparent 20%,
+    var(--bg) 80%,
+    var(--bg) 100%
   );
   color: var(--text);
   /* Restore type defaults that .archive-entry zeroed out for layout. */


### PR DESCRIPTION
Flip direction to `to bottom` so the gradient stops match the spec literally instead of needing a mental flip from `to top`'s reversed coordinate system.