### PR TITLE
Project card relayout, home row width, archive blur, hover consistency

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -152,7 +152,7 @@ header.site-header {
   flex-direction: column;
   gap: 0;
 }
-.posts-feed li { display: block; padding: 0; margin: 0; }
+.posts-feed li { display: block; padding: 0; margin: 0; width: 100%; }
 .posts-feed-row,
 .posts-feed-row:visited {
   display: grid;
@@ -160,11 +160,13 @@ header.site-header {
   align-items: baseline;
   column-gap: 1em;
   row-gap: 0.15em;
+  width: 100%;
+  box-sizing: border-box;
   padding: 0.4rem 0.55rem;
   border-radius: 6px;
   color: var(--text);
   text-decoration: none;
-  transition: background-color .15s ease;
+  transition: background-color .15s ease, color .15s ease;
 }
 .posts-feed-row:hover,
 .posts-feed-row:focus-visible {

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -258,7 +258,7 @@ img.avatar {
   border-radius: 8px;
   background: var(--surface);
   box-shadow: 0 1px 2px rgba(0, 0, 0, .06);
-  transition: box-shadow .25s ease, transform .25s ease;
+  transition: box-shadow .2s ease, transform .2s ease;
   /* Collapse any inline whitespace inside the <li> so the cover image
      sits flush against the card's top edge. .archive-entry-content
      restores font-size / line-height for its own text. */
@@ -303,6 +303,11 @@ img.avatar {
     var(--bg) 80%,
     var(--bg) 100%
   );
+  /* Blur the cover image visible through the gradient ramp. The
+     opaque bottom of the gradient hides the blur; the transparent
+     top shows a blurred slice of the image. */
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
   color: var(--text);
   /* Restore type defaults that .archive-entry zeroed out for layout. */
   font-size: 1rem;
@@ -315,7 +320,9 @@ img.avatar {
   letter-spacing: -0.015em;
   line-height: 1.2;
   font-weight: 600;
+  transition: color .2s ease;
 }
+.archive-entry:hover .archive-entry-title { color: var(--accent); }
 .archive-entry-meta {
   margin: 0 0 0.4rem;
   font-size: 0.82rem;
@@ -350,7 +357,7 @@ img.avatar {
   background: var(--surface);
   border-radius: 8px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, .06);
-  transition: transform .25s ease, box-shadow .25s ease;
+  transition: transform .2s ease, box-shadow .2s ease;
   isolation: isolate;
   will-change: transform;
 }
@@ -370,15 +377,14 @@ img.avatar {
 .project-card-row {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  margin: 0 0 0.7rem;
+  gap: 1rem;
+  margin: 0 0 0.9rem;
 }
 .project-card-logo,
 .post-content .project-card-logo {
-  flex: 0 0 2.75rem;
-  width: 2.75rem;
-  height: 2.75rem;
+  flex: 0 0 3rem;
+  width: 3rem;
+  height: 3rem;
   display: block;
   /* override .post-content img { margin: 1.4em auto } that would
      otherwise auto-center the icon and add vertical margin */
@@ -386,26 +392,29 @@ img.avatar {
   border-radius: 0;
   max-width: none;
 }
+.project-card-meta {
+  flex: 1 1 0;
+  min-width: 0;
+}
 .project-card-title {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin: 0;
+  margin: 0 0 0.15rem;
   font-size: 1.2rem;
   font-weight: 600;
   line-height: 1.25;
   letter-spacing: -0.01em;
   color: var(--text);
+  transition: color .2s ease;
 }
 .project-card:hover .project-card-title { color: var(--accent); }
 .project-card-tagline {
   margin: 0;
-  flex: 1 1 14rem;
-  min-width: 0;
   color: var(--text-muted);
-  font-size: 0.95rem;
-  line-height: 1.45;
+  font-size: 0.92rem;
+  line-height: 1.4;
 }
 .project-card-desc {
   margin: 0;

--- a/projects/index.md
+++ b/projects/index.md
@@ -19,15 +19,17 @@ description: "Things Viktor Shcherbakov is building. Currently featured: jseek.c
           {%- if p.logo -%}
             <img class="project-card-logo" src="{{ p.logo | relative_url }}" alt="" loading="lazy" decoding="async">
           {%- endif -%}
-          <h2 class="project-card-title">
-            {{ p.title }}
-            {%- if p.status -%}
-              <span class="project-status project-status--{{ p.status }}">{{ p.status }}</span>
+          <div class="project-card-meta">
+            <h2 class="project-card-title">
+              {{ p.title }}
+              {%- if p.status -%}
+                <span class="project-status project-status--{{ p.status }}">{{ p.status }}</span>
+              {%- endif -%}
+            </h2>
+            {%- if p.tagline -%}
+              <p class="project-card-tagline">{{ p.tagline }}</p>
             {%- endif -%}
-          </h2>
-          {%- if p.tagline -%}
-            <p class="project-card-tagline">{{ p.tagline }}</p>
-          {%- endif -%}
+          </div>
         </div>
         {%- if p.description -%}
           <p class="project-card-desc">{{ p.description | strip_newlines | strip }}</p>


### PR DESCRIPTION
Lots of small fixes after the latest visual review:

- Project card: [icon] | [title-over-tagline] / description below.
- Home rows: width: 100% on the link + li so dates and taglines hit the right edge instead of stopping early when the title is short.
- Blog archive: add backdrop-filter: blur(8px) on the gradient panel; the existing gradient already keeps the bottom solid for legible text.
- Hover: unify card transitions to .2s, add accent-on-hover for blog archive title to match project cards.