### PR TITLE
Steep blur ramp + mobile stacked layout

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -160,7 +160,7 @@ header.site-header {
 .posts-feed-row,
 .posts-feed-row:visited {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: baseline;
   column-gap: 1em;
   row-gap: 0.15em;
@@ -171,6 +171,19 @@ header.site-header {
   color: var(--text);
   text-decoration: none;
   transition: background-color .15s ease, color .15s ease;
+}
+/* On narrow viewports drop the side-by-side date/tagline column —
+   stack title above the metadata so the title can use full row width
+   without overflow. */
+@media (max-width: 30rem) {
+  .posts-feed-row {
+    grid-template-columns: 1fr;
+    row-gap: 0.1em;
+  }
+  .posts-feed time,
+  .featured-projects .posts-feed-row .project-tagline {
+    text-align: left;
+  }
 }
 .posts-feed-row:hover,
 .posts-feed-row:focus-visible {

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -303,13 +303,17 @@ img.avatar {
   position: absolute;
   inset: auto 0 0 0;
   padding: 4.5rem 1.4rem 1.3rem;
-  /* Direction `to bottom` so 0 % = top of the panel, 100 % = bottom.
-     Top 20 % transparent, 20–80 % linear ramp, bottom 20 % solid. */
+  /* Direction `to bottom`. Aggressive ease-in: top 15 % fully
+     transparent (image sharp), then a steep ramp finishing by 28 %
+     so the title (which sits around 30 % from the top of the panel)
+     is already on a solid var(--bg) backdrop. */
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    transparent 20%,
-    var(--bg) 80%,
+    transparent 15%,
+    color-mix(in srgb, var(--bg) 60%, transparent) 20%,
+    color-mix(in srgb, var(--bg) 90%, transparent) 24%,
+    var(--bg) 28%,
     var(--bg) 100%
   );
   color: var(--text);
@@ -331,8 +335,27 @@ img.avatar {
   pointer-events: none;
   -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
-  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, transparent 20%, #000 80%, #000 100%);
-  mask-image: linear-gradient(to bottom, transparent 0%, transparent 20%, #000 80%, #000 100%);
+  /* Same aggressive ease-in as the bg gradient so the blur intensity
+     matches the cream tint at every Y position. By the title's
+     vertical position the blur is at full strength. */
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 15%,
+    rgba(0, 0, 0, 0.6) 20%,
+    rgba(0, 0, 0, 0.9) 24%,
+    #000 28%,
+    #000 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 15%,
+    rgba(0, 0, 0, 0.6) 20%,
+    rgba(0, 0, 0, 0.9) 24%,
+    #000 28%,
+    #000 100%
+  );
 }
 .archive-entry-title,
 .post-content .archive-entry-title {
@@ -575,3 +598,37 @@ th, td {
   border-bottom: 1px solid var(--border);
 }
 th { color: var(--text); font-weight: 600; }
+
+/* --- Mobile: stacked blog cards (image + text), no gradient overlay
+       --- */
+@media (max-width: 30rem) {
+  .archive-entry-cover {
+    aspect-ratio: 16 / 10;
+  }
+  .archive-entry-content {
+    position: static;
+    inset: auto;
+    padding: 1.1rem 1rem 1.2rem;
+    background: var(--surface);
+  }
+  .archive-entry-content::before { display: none; }
+  .archive-entry-title,
+  .post-content .archive-entry-title {
+    font-size: 1.15rem;
+  }
+  .archive-entry-desc { font-size: 0.88rem; }
+
+  /* Project card breathing room on small viewports */
+  .project-card-link,
+  .post-content .project-card-link,
+  .post-content .project-card-link:visited {
+    padding: 1.1rem 1rem;
+  }
+  .project-card-row { gap: 0.85rem; }
+  .project-card-logo,
+  .post-content .project-card-logo {
+    flex: 0 0 2.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+}


### PR DESCRIPTION
Two fixes:

1. Blog card title was sitting on the 13%-opaque part of the linear gradient ramp, making it hard to read. Replace with a non-linear ease-in: top 15% transparent (image sharp), steep ramp 15→28%, fully solid 28→100% — so the title row is on fully opaque var(--bg). Same shape applied to the blur mask so blur hits full strength alongside the gradient.

2. At ≤ 30 rem (mobile): drop the absolute-positioned overlay panel; cover and text stack vertically inside the card with solid surface bg. Drop the blur pseudo on mobile. Home posts-feed rows stack title above date/tagline and left-align metadata, fixing the title↔tagline overlap at 375 px viewport.