### PR TITLE
Widen content to 50rem; flush archive thumbnails

### DIFF
--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -48,7 +48,7 @@ body {
 }
 
 .wrapper {
-  max-width: 38rem;
+  max-width: 50rem;
   margin-inline: auto;
   padding: 2.5rem 1.5rem 2.5rem;
   position: relative;

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -275,13 +275,17 @@ img.avatar {
 .archive-entry-link:visited,
 .post-content .archive-entry-link,
 .post-content .archive-entry-link:visited {
-  display: block;
+  /* flex column eliminates the anonymous line box that would otherwise
+     leave a sliver of surface visible above the cover image. */
+  display: flex;
+  flex-direction: column;
   color: var(--text);
   text-decoration: none;
 }
 /* Kill any inherited underlines from .post-content a rules. */
 .archive-entry-link * { text-decoration: none !important; }
-.archive-entry-cover {
+.archive-entry-cover,
+.post-content .archive-entry-cover {
   display: block;
   width: 100%;
   height: auto;
@@ -289,7 +293,10 @@ img.avatar {
      object-fit: cover doesn't shave the sides off. */
   aspect-ratio: 1600 / 840;
   object-fit: cover;
+  /* Beat the .post-content img { margin: 1.4em auto } rule that would
+     otherwise push the cover down inside its rounded card. */
   margin: 0;
+  border-radius: 0;
 }
 .archive-entry-content {
   padding: 1.1rem 1.2rem 1.3rem;


### PR DESCRIPTION
## Summary
- Wrapper \`max-width\` 38rem → 50rem (~30% wider) — gives the 2-col blog grid more breathing room and the project card a more substantial footprint.
- Fix top gap above blog archive thumbnails: \`.post-content img { margin: 1.4em auto }\` was cascading onto the cover image. Override with a higher-specificity selector on \`.archive-entry-cover\`. Also drop the inherited 6px image radius since the card already clips.
- Make \`.archive-entry-link\` a flex column so any anonymous inline whitespace can't reintroduce a baseline gap.

## Verified
- Desktop screenshots of /, /blog/, /projects/ — wider layout reads well, thumbnails sit flush against the rounded top of each card.