### PR TITLE
Fix project hero logo drifting after 50rem widen

### DIFF
--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -422,11 +422,17 @@ img.avatar {
   gap: 1.25rem;
   margin: 0 0 2rem;
 }
-.project-logo {
+.project-logo,
+.post-content .project-logo {
   width: 5.5rem;
   height: 5.5rem;
   flex-shrink: 0;
   display: block;
+  /* Defeat .post-content img { margin: 1.4em auto } — inside a flex
+     container the auto horizontal margin would eat all the free space
+     and float the logo into the middle of the row. */
+  margin: 0;
+  border-radius: 0;
 }
 .project-hero-text { min-width: 0; }
 .project-title {


### PR DESCRIPTION
## Summary
- Same \`.post-content img { margin: 1.4em auto }\` trap that bit the archive cover. Inside \`.project-hero\` (flex), the \`auto\` horizontal margin distributes free space, pushing the logo into the middle of the row. The wider 50rem wrapper made it visually worse since there's more free space.
- Override at \`.post-content .project-logo\` with \`margin: 0\` — same pattern \`.project-card-logo\` already had.

## Verified
- Local screenshot of /projects/jseek/ — logo flush left next to title.