### PR TITLE
Show status pill in featured-projects widget

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -118,7 +118,12 @@
               {%- for p in featured_projects -%}
                 <li>
                   <a class="posts-feed-row" href="{{ p.url | relative_url }}">
-                    <span class="posts-feed-title">{{ p.title }}</span>
+                    <span class="posts-feed-title">
+                      {{ p.title }}
+                      {%- if p.status -%}
+                        <span class="project-status project-status--{{ p.status }}">{{ p.status }}</span>
+                      {%- endif -%}
+                    </span>
                     <span class="project-tagline">{{ p.tagline }}</span>
                   </a>
                 </li>


### PR DESCRIPTION
Mirror the projects index — render `.project-status` pill next to the title in the home featured-projects list.