### PR TITLE
Fill in home + /about/ bodies

### DIFF
--- a/_includes/currently.html
+++ b/_includes/currently.html
@@ -1,0 +1,15 @@
+{%- comment -%}
+"Currently" block, shared between / and /about/. Pass `heading_level`
+(default h3) to control the heading element so the block sits at the
+right depth in each page's heading hierarchy. To refresh: edit the
+date and the bullets together.
+{%- endcomment -%}
+{%- assign hl = include.heading_level | default: 'h3' -%}
+<{{ hl }} id="currently">Currently <span class="currently-date">— May 2026</span></{{ hl }}>
+
+<ul>
+  <li>Working on LLMs at <strong>MLO, EPFL</strong>.</li>
+  <li>Running <a href="{{ '/projects/jseek/' | relative_url }}">jseek.co</a> as a small side product.</li>
+  <li>Slowly retooling this site and writing more.</li>
+  <li>Settling deeper into Lausanne — paperwork, neighbourhood, the lake.</li>
+</ul>

--- a/about.md
+++ b/about.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "About"
-description: "Machine-learning engineer based in Geneva, Switzerland. Alumnus of the University of Geneva and Lomonosov Moscow State University."
+description: "ML research engineer at EPFL's MLO group, based in Lausanne. Originally from Moscow; degrees from MSU and the University of Geneva."
 permalink: /about/
 image: "https://github.com/viktor-shcherb.png?size=600"
 image_alt: "Photograph of Viktor Shcherbakov"
@@ -15,4 +15,24 @@ schema: person
      loading="lazy"
      decoding="async">
 
-WIP
+I grew up in Moscow. I studied computer science at MSU's Faculty of Computational Mathematics and Cybernetics, and spent most evenings during the BSc at the Russian Academy of Sciences — deploying and fine-tuning BERT on whichever custom task the lab was chasing that month. My first real ML job, paid by the hour, slowly figuring out the difference between a model that fits and a model that ships.
+
+I came to Switzerland aiming for a PhD at EPFL. The route's been a detour: an MSc in computer science from the University of Geneva, then a stretch at UNIL's Digital Markets lab on the intersection of AI and digital-platform economics. I'm now an ML research engineer at EPFL's MLO group, working on LLMs. The PhD is still the goal.
+
+Side projects keep me honest. **[jseek.co]({{ '/projects/jseek/' | relative_url }})** — a watchlist-style aggregator for company career pages — began as the scraper I wrote for myself during a long Swiss job hunt and grew into something I now run as a small product. There's usually something else half-built on the side too.
+
+{% include currently.html heading_level="h2" %}
+
+## What I write about
+
+- **Life in Switzerland** — work permits, apartments, the small machinery of moving here. Most posts so far live here.
+- **ML and research** — notes from the LLM side of the work, eventually papers.
+- **Building** — small products and the engineering behind them. jseek.co lives here.
+
+## Publications
+
+Papers will land here as they come out. Until then, [Google Scholar](https://scholar.google.com/citations?user=WA2IuM4AAAAJ&hl=en) and [ORCID](https://orcid.org/0000-0003-1098-9548) are the canonical record.
+
+## Contact
+
+Best for **collaborations and opportunities** — `viktoroo.sch@gmail.com`. Slow to reply, but I do reply.

--- a/assets/css/_base.scss
+++ b/assets/css/_base.scss
@@ -505,6 +505,14 @@ img.avatar {
   margin-left: 0.4em;
 }
 
+/* --- Currently block (shared by / and /about/) --- */
+.currently-date {
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 0.85em;
+  letter-spacing: 0;
+}
+
 /* --- Footer --- */
 .site-footer {
   margin-top: 4rem;

--- a/index.md
+++ b/index.md
@@ -1,11 +1,13 @@
 ---
 layout: default
 title: "Viktor Shcherbakov"
-description: "Personal site of Viktor Shcherbakov, a machine-learning engineer based in Switzerland. Long-form notes on ML, software, and the practical side of working in Switzerland as a non-EU graduate."
+description: "Personal site of Viktor Shcherbakov, ML research engineer at EPFL's MLO group. Long-form notes on ML, software, and life in Switzerland as a non-EU graduate."
 image: /logos-flavicon/web-app-manifest-512x512.png
 image_alt: "Viktor Shcherbakov stamp logo"
 permalink: /
 home: true
 ---
 
-Welcome — long-form thoughts and projects, slowly.
+This is where I keep notes. ML research at EPFL pays the bills, side projects keep me honest, and life in Switzerland keeps me amused. Long-form thoughts and projects, slowly.
+
+{% include currently.html %}


### PR DESCRIPTION
## Summary
- Home: replace `Welcome — long-form thoughts and projects, slowly` with a 3-line intro + a Currently block.
- /about/: bio narrative (Moscow → MSU/RAS → detour through UNIGE/UNIL → MLO at EPFL), Currently, What-I-write-about, Publications placeholder + Scholar/ORCID, email contact.
- Single `_includes/currently.html` so home and about don't drift; `heading_level` arg picks h2/h3.

## Verified
- Local screenshots of / and /about/ — layout reads cleanly, no orphaned widgets, currently block on both pages.