### PR TITLE
Optimize README + repo metadata for traffic

### DIFF
--- a/.github/workflows/refresh-readme.yml
+++ b/.github/workflows/refresh-readme.yml
@@ -1,0 +1,36 @@
+name: Refresh README recent posts
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "_posts/**"
+      - "scripts/update_readme_posts.py"
+      - ".github/workflows/refresh-readme.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-readme
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Refresh recent posts
+        run: python3 scripts/update_readme_posts.py
+      - name: Commit if changed
+        run: |
+          if [[ -n $(git status --porcelain README.md) ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add README.md
+            git commit -m "chore: refresh recent posts in README"
+            git push
+          else
+            echo "README already up to date."
+          fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
-This repository contains the source for my personal website. The site is built with [Jekyll](https://jekyllrb.com/) and hosts my blog and pages about me.
+<a href="https://vshcherbakov.com">
+  <img src="https://vshcherbakov.com/assets/images/og/og-default.png" alt="Viktor Shcherbakov — ML Research Engineer at EPFL" width="100%">
+</a>
 
-Feel free to explore the code or open issues for suggestions and feedback.
+# vshcherbakov.com
+
+Source for [**vshcherbakov.com**](https://vshcherbakov.com) — my personal site and blog.
+
+I'm an ML research engineer at [EPFL's MLO group](https://www.epfl.ch/labs/mlo/), based in Lausanne. I write long-form notes on machine-learning research, the side projects I'm building, and the practical side of life in Switzerland as a non-EU graduate.
+
+→ [About](https://vshcherbakov.com/about/) · [Blog](https://vshcherbakov.com/blog/) · [Projects](https://vshcherbakov.com/projects/) · [Atom feed](https://vshcherbakov.com/feed.xml)
+
+## Recently on the blog
+<!-- RECENT_POSTS_START -->
+- [What worked when we applied for apartments in Lausanne](https://vshcherbakov.com/2026/05/08/What-worked-when-we-applied-for-apartments-in-Lausanne/) — 2026-05
+- [Path to working permits for Swiss graduates](https://vshcherbakov.com/2025/06/26/Path-to-working-permit-for-Swiss-graduates/) — 2025-06
+<!-- RECENT_POSTS_END -->
+
+## Stack
+
+Jekyll · GitHub Pages · custom SCSS · Cloudflare DNS. The custom `feed.xml` honors per-post `hidden: true`. Read the source if you're curious how something is put together.
+
+## Side project
+
+**[jseek.co](https://jseek.co)** — a watchlist-style aggregator for company career pages. Started as a scraper I wrote for myself during a long Swiss job hunt; now a small running product.

--- a/scripts/update_readme_posts.py
+++ b/scripts/update_readme_posts.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Refresh the 'Recently on the blog' block in README.md from _posts/.
+
+Parses the post filenames + frontmatter directly so it doesn't depend on
+a built site or a published feed (no race with GH Pages deploy).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+README = ROOT / "README.md"
+POSTS_DIR = ROOT / "_posts"
+SITE_URL = "https://vshcherbakov.com"
+START = "<!-- RECENT_POSTS_START -->"
+END = "<!-- RECENT_POSTS_END -->"
+N = 5
+
+FILENAME_RE = re.compile(
+    r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})-(?P<slug>.+)\.md$"
+)
+
+
+def parse_post(path: Path):
+    m = FILENAME_RE.match(path.name)
+    if not m:
+        return None
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    frontmatter = parts[1]
+    if re.search(r"^hidden:\s*true\b", frontmatter, re.MULTILINE):
+        return None
+    if re.search(r"^sitemap:\s*false\b", frontmatter, re.MULTILINE):
+        return None
+    title_match = re.search(r"^title:\s*(.+)$", frontmatter, re.MULTILINE)
+    if not title_match:
+        return None
+    title = title_match.group(1).strip().strip('"').strip("'")
+    date = f"{m['year']}-{m['month']}-{m['day']}"
+    url = f"{SITE_URL}/{m['year']}/{m['month']}/{m['day']}/{m['slug']}/"
+    return (date, title, url)
+
+
+def main():
+    posts = []
+    for path in POSTS_DIR.glob("*.md"):
+        parsed = parse_post(path)
+        if parsed:
+            posts.append(parsed)
+    posts.sort(key=lambda x: x[0], reverse=True)
+    posts = posts[:N]
+
+    if posts:
+        body = "\n".join(
+            f"- [{title}]({url}) — {date[:7]}" for date, title, url in posts
+        )
+    else:
+        body = "_No posts yet._"
+
+    text = README.read_text(encoding="utf-8")
+    pattern = re.compile(rf"{re.escape(START)}.*?{re.escape(END)}", re.DOTALL)
+    new_block = f"{START}\n{body}\n{END}"
+    if not pattern.search(text):
+        raise SystemExit(
+            f"README.md is missing the {START} ... {END} marker block."
+        )
+    updated = pattern.sub(new_block, text)
+    if updated == text:
+        print("README unchanged.")
+        return
+    README.write_text(updated, encoding="utf-8")
+    print("README updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Replaces the 3-line README with a hero image (clickable to live site), bio matching about.md, link rail to all top-level pages, and a side-project mention.
- Adds an auto-updated **Recently on the blog** block — a marker pair (\`<!-- RECENT_POSTS_START -->\` / \`<!-- RECENT_POSTS_END -->\`) is rewritten by \`scripts/update_readme_posts.py\` whenever \`_posts/**\` changes. Parses post filenames + frontmatter directly, so no race with GH Pages deploy and no extra network calls.
- Fixes repo metadata via \`gh repo edit\`:
  - description rewritten with name, role, location, and topic anchors
  - homepage URL canonicalized to \`https://vshcherbakov.com\`
  - topics extended with \`machine-learning\`, \`epfl\`, \`switzerland\`, \`writing\`

## Why
The repo README and GitHub About panel are the highest-ranking surfaces for searches like \`viktor shcherbakov\` and for GitHub topic browsing. They were essentially blank before — pure conversion lift, near-zero ongoing maintenance.

## Test plan
- [x] Script runs locally and produces correct, sorted entries (excludes \`hidden: true\` + \`sitemap: false\` posts)
- [x] \`gh repo view\` confirms description / homepage / topics applied
- [ ] After merge: workflow runs on next \`_posts/**\` change and commits a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)